### PR TITLE
fix: resolve EMFILE (too many open files) in MCP server background indexer

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "rulebook",
   "description": "Standardize AI-generated projects with Ralph autonomous loop, persistent memory, and quality gates. Supports 28 languages, 17 frameworks, 13 MCP modules, and 20 services.",
-  "version": "5.1.2",
+  "version": "5.1.3",
   "author": {
     "name": "HiveLLM"
   }

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           codespell \
             --skip="*.lock,*.json,*.map,*.yaml,*.yml,*.csv,*.bib,target,node_modules,.git,dist,venv,build,benchmarks,coverage,templates" \
-            --ignore-words-list="crate,ser,deser,upToDate,optIn,shouldBe,Bloc"
+            --ignore-words-list="crate,ser,deser,upToDate,optIn,shouldBe,Bloc,thirdparty"
           # MONOREPO NOTE: Add multilingual stopwords to ignore-words-list if needed
           # Example: --ignore-words-list="crate,ser,deser,meu,oder,ist,alle" (Portuguese,German,etc)
 

--- a/.rulebook/rulebook.json
+++ b/.rulebook/rulebook.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.1.2",
+  "version": "5.1.3",
   "installedAt": "2026-03-13T08:07:02.815Z",
   "updatedAt": "2026-03-19T22:43:13.672Z",
   "projectId": "rulebook",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.1.3] - 2026-03-27
+
+### Fixed — MCP Server EMFILE (Too Many Open Files)
+
+- **Function-based chokidar ignore**: Replaced glob-string `ignored` patterns with a function that prevents chokidar from entering `node_modules`, `.git`, `dist`, `build`, `.rulebook`, and `coverage` directories at the OS watcher level — eliminating the root cause of 60,000+ open file descriptors on macOS.
+- **Reduced default watch depth**: Changed from `depth: 8` to `depth: 4`, significantly reducing file descriptor consumption.
+- **Watch path resolution**: The `watchPaths` config is now actually used (previously always watched project root). Paths are resolved to absolute and validated before watching.
+- **EMFILE auto-recovery**: On `EMFILE`/`ENFILE` errors, the indexer automatically restarts in polling mode as a fallback (one retry only).
+- **Configurable indexer settings**: New `indexer` section in `.rulebook` config allows customizing `watchPaths`, `ignorePatterns`, `depth`, `usePolling`, and `debounceMs`.
+
 ## [5.1.2] - 2026-03-26
 
 ### Fixed — MCP Server Per-Session PID Lock

--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ npx @hivehub/rulebook@latest rules project   # Project to all tools
 
 See the full [CHANGELOG](CHANGELOG.md) for details.
 
+### v5.1.3 — MCP Server EMFILE Fix
+
+Fixed a critical issue where the MCP server's background indexer opened 60,000+ file descriptors on macOS (default ulimit 256), causing `EMFILE: too many open files` crashes. Replaced glob-string ignore patterns with function-based filtering that prevents chokidar from entering `node_modules`/`.git`/`dist` directories. Reduced default watch depth from 8 to 4, added EMFILE auto-recovery to polling mode, and made indexer settings configurable via `.rulebook` config.
+
 ### v5.1.2 — MCP Per-Session PID Lock
 
 Fixed a critical issue where only one VSCode/Claude Code window could use the MCP server at a time. The PID lock now uses **session-scoped files** (`mcp-server.<pid>.pid`) instead of a single global lock, allowing multiple concurrent MCP instances. Stale PID files from dead processes are automatically cleaned on startup, with backward-compatible cleanup of the legacy format.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hivehub/rulebook",
-  "version": "5.1.2",
+  "version": "5.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hivehub/rulebook",
-      "version": "5.1.2",
+      "version": "5.1.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.22.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hivehub/rulebook",
-  "version": "5.1.2",
+  "version": "5.1.3",
   "description": "Tool-agnostic AI development framework. Standardize projects across Claude Code, Cursor, Gemini, Codex, Windsurf, Copilot with automated templates, quality gates, persistent memory, and framework detection for 28 languages, 17 frameworks, 13 MCP modules, and 20 services",
   "type": "module",
   "main": "dist/index.js",

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -358,9 +358,21 @@ export async function initCommand(options: {
       const templatesDir = getTemplatesDir();
 
       // Tier 1 rules — always installed
-      const tier1Rules = ['no-shortcuts', 'git-safety', 'sequential-editing', 'research-first', 'follow-task-sequence', 'incremental-implementation'];
+      const tier1Rules = [
+        'no-shortcuts',
+        'git-safety',
+        'sequential-editing',
+        'research-first',
+        'follow-task-sequence',
+        'incremental-implementation',
+      ];
       // Tier 2 rules — installed for medium+ complexity
-      const tier2Rules = ['task-decomposition', 'incremental-tests', 'no-deferred', 'session-workflow'];
+      const tier2Rules = [
+        'task-decomposition',
+        'incremental-tests',
+        'no-deferred',
+        'session-workflow',
+      ];
 
       const rulesToInstall = [...tier1Rules];
       if (complexity.recommendations.tier2Rules) {
@@ -374,12 +386,15 @@ export async function initCommand(options: {
       }
 
       if (installedCount > 0) {
-        console.log(chalk.gray(`  • Installed ${installedCount} canonical rules to .rulebook/rules/`));
+        console.log(
+          chalk.gray(`  • Installed ${installedCount} canonical rules to .rulebook/rules/`)
+        );
       }
 
       // Project rules to detected tools
       const ruleResult = await projectRules(cwd, {
-        claudeCode: existsSync(path.join(cwd, '.claude')) || existsSync(path.join(cwd, 'CLAUDE.md')),
+        claudeCode:
+          existsSync(path.join(cwd, '.claude')) || existsSync(path.join(cwd, 'CLAUDE.md')),
         cursor: detection.cursor?.detected,
         gemini: detection.geminiCli?.detected,
         windsurf: detection.windsurf?.detected,
@@ -388,8 +403,12 @@ export async function initCommand(options: {
       });
 
       const totalProjected =
-        ruleResult.claudeCode.length + ruleResult.cursor.length + ruleResult.gemini.length +
-        ruleResult.copilot.length + ruleResult.windsurf.length + ruleResult.continueDev.length;
+        ruleResult.claudeCode.length +
+        ruleResult.cursor.length +
+        ruleResult.gemini.length +
+        ruleResult.copilot.length +
+        ruleResult.windsurf.length +
+        ruleResult.continueDev.length;
 
       if (totalProjected > 0) {
         console.log(chalk.gray(`  • Projected rules to ${totalProjected} tool-specific files`));
@@ -583,9 +602,7 @@ export async function initCommand(options: {
         )
       );
       console.log(
-        chalk.yellow(
-          '  The MCP server will auto-detect workspace mode. For explicit setup, run:'
-        )
+        chalk.yellow('  The MCP server will auto-detect workspace mode. For explicit setup, run:')
       );
       console.log(chalk.yellow('    rulebook workspace init'));
       console.log(
@@ -2035,7 +2052,9 @@ async function updateSingleProject(
   // Install + project canonical rules to all detected tools (v5 rule engine)
   // On update: if .rulebook/rules/ is empty (v4 project), auto-install based on complexity
   {
-    const { projectRules, installRule, loadCanonicalRules } = await import('../core/rule-engine.js');
+    const { projectRules, installRule, loadCanonicalRules } = await import(
+      '../core/rule-engine.js'
+    );
     const existingRules = await loadCanonicalRules(cwd);
 
     if (existingRules.length === 0) {
@@ -2045,7 +2064,14 @@ async function updateSingleProject(
       const complexity = assessComplexity(cwd);
       const templatesDir = getTemplatesDir();
 
-      const tier1 = ['no-shortcuts', 'git-safety', 'sequential-editing', 'research-first', 'follow-task-sequence', 'incremental-implementation'];
+      const tier1 = [
+        'no-shortcuts',
+        'git-safety',
+        'sequential-editing',
+        'research-first',
+        'follow-task-sequence',
+        'incremental-implementation',
+      ];
       const tier2 = ['task-decomposition', 'incremental-tests', 'no-deferred', 'session-workflow'];
 
       const toInstall = [...tier1];
@@ -4654,7 +4680,10 @@ export async function workspaceStatusCommand(): Promise<void> {
 
 // Context Intelligence Layer commands (v4.4)
 
-export async function decisionCreateCommand(title: string, options: { context?: string; relatedTask?: string }): Promise<void> {
+export async function decisionCreateCommand(
+  title: string,
+  options: { context?: string; relatedTask?: string }
+): Promise<void> {
   const { DecisionManager } = await import('../core/decision-manager.js');
   const mgr = new DecisionManager(process.cwd());
   const spinner = ora('Creating decision...').start();
@@ -4678,7 +4707,12 @@ export async function decisionListCommand(options: { status?: string }): Promise
     return;
   }
   for (const d of decisions) {
-    const badge = d.status === 'accepted' ? chalk.green(d.status) : d.status === 'superseded' ? chalk.dim(d.status) : chalk.yellow(d.status);
+    const badge =
+      d.status === 'accepted'
+        ? chalk.green(d.status)
+        : d.status === 'superseded'
+          ? chalk.dim(d.status)
+          : chalk.yellow(d.status);
     console.log(`  ADR-${String(d.id).padStart(3, '0')}  ${d.title}  ${badge}`);
   }
 }
@@ -4705,7 +4739,11 @@ export async function decisionSupersedeCommand(oldId: string, newId: string): Pr
   }
 }
 
-export async function knowledgeAddCommand(type: string, title: string, options: { category?: string; description?: string }): Promise<void> {
+export async function knowledgeAddCommand(
+  type: string,
+  title: string,
+  options: { category?: string; description?: string }
+): Promise<void> {
   const { KnowledgeManager } = await import('../core/knowledge-manager.js');
   const mgr = new KnowledgeManager(process.cwd());
   const spinner = ora('Adding knowledge entry...').start();
@@ -4720,7 +4758,10 @@ export async function knowledgeAddCommand(type: string, title: string, options: 
   }
 }
 
-export async function knowledgeListCommand(options: { type?: string; category?: string }): Promise<void> {
+export async function knowledgeListCommand(options: {
+  type?: string;
+  category?: string;
+}): Promise<void> {
   const { KnowledgeManager } = await import('../core/knowledge-manager.js');
   const mgr = new KnowledgeManager(process.cwd());
   const entries = await mgr.list(options.type as any, options.category as any);
@@ -4756,14 +4797,19 @@ export async function knowledgeRemoveCommand(id: string): Promise<void> {
   }
 }
 
-export async function learnCaptureCommand(options: { title?: string; content?: string; relatedTask?: string; tags?: string }): Promise<void> {
+export async function learnCaptureCommand(options: {
+  title?: string;
+  content?: string;
+  relatedTask?: string;
+  tags?: string;
+}): Promise<void> {
   const { LearnManager } = await import('../core/learn-manager.js');
   const mgr = new LearnManager(process.cwd());
 
   // If no title/content provided, this would be interactive (placeholder for prompts)
   const title = options.title ?? 'Untitled learning';
   const content = options.content ?? '';
-  const tags = options.tags ? options.tags.split(',').map(t => t.trim()) : [];
+  const tags = options.tags ? options.tags.split(',').map((t) => t.trim()) : [];
 
   const spinner = ora('Capturing learning...').start();
   try {
@@ -4804,13 +4850,22 @@ export async function learnListCommand(options: { limit?: string }): Promise<voi
     return;
   }
   for (const l of learnings) {
-    const badge = l.source === 'ralph' ? chalk.blue('ralph') : l.source === 'task-archive' ? chalk.yellow('archive') : chalk.dim('manual');
+    const badge =
+      l.source === 'ralph'
+        ? chalk.blue('ralph')
+        : l.source === 'task-archive'
+          ? chalk.yellow('archive')
+          : chalk.dim('manual');
     const promoted = l.promotedTo ? chalk.green(` → ${l.promotedTo.type}`) : '';
     console.log(`  ${badge}  ${l.title}${promoted}`);
   }
 }
 
-export async function learnPromoteCommand(id: string, target: string, options: { title?: string }): Promise<void> {
+export async function learnPromoteCommand(
+  id: string,
+  target: string,
+  options: { title?: string }
+): Promise<void> {
   const { LearnManager } = await import('../core/learn-manager.js');
   const mgr = new LearnManager(process.cwd());
 

--- a/src/core/agent-template-engine.ts
+++ b/src/core/agent-template-engine.ts
@@ -79,7 +79,11 @@ function parseFrontmatter(content: string): { meta: Record<string, unknown>; bod
 
     // Inline array: ["a", "b"]
     if (typeof val === 'string' && val.startsWith('[') && val.endsWith(']')) {
-      val = val.slice(1, -1).split(',').map(s => s.trim().replace(/^["']|["']$/g, '')).filter(Boolean);
+      val = val
+        .slice(1, -1)
+        .split(',')
+        .map((s) => s.trim().replace(/^["']|["']$/g, ''))
+        .filter(Boolean);
     } else if (val === 'true') val = true;
     else if (val === 'false') val = false;
     else if (typeof val === 'string') val = val.replace(/^["']|["']$/g, '');
@@ -132,11 +136,11 @@ async function loadFromDir(dir: string, templates: AgentTemplate[]): Promise<voi
     templates.push({
       name: (meta.name as string) || basename(file, '.md'),
       domain: (meta.domain as string) || 'general',
-      filePatterns: Array.isArray(meta.filePatterns) ? meta.filePatterns as string[] : ['*'],
+      filePatterns: Array.isArray(meta.filePatterns) ? (meta.filePatterns as string[]) : ['*'],
       tier: (meta.tier as ModelTier) || 'standard',
       model: (meta.model as string) || 'sonnet',
       description: (meta.description as string) || '',
-      checklist: Array.isArray(meta.checklist) ? meta.checklist as string[] : [],
+      checklist: Array.isArray(meta.checklist) ? (meta.checklist as string[]) : [],
       body: body.trim(),
     });
   }
@@ -251,7 +255,11 @@ async function generateCursorAgentRules(
 
   for (const tmpl of templates) {
     // Skip generic agents that don't have meaningful file patterns
-    if (tmpl.filePatterns.length === 1 && tmpl.filePatterns[0] === '*' && tmpl.domain === 'research') {
+    if (
+      tmpl.filePatterns.length === 1 &&
+      tmpl.filePatterns[0] === '*' &&
+      tmpl.domain === 'research'
+    ) {
       continue;
     }
 
@@ -363,7 +371,9 @@ export async function generateAgents(
 /**
  * List available project types and their agent counts.
  */
-export async function listProjectTypes(): Promise<Array<{ type: ProjectType; agentCount: number }>> {
+export async function listProjectTypes(): Promise<
+  Array<{ type: ProjectType; agentCount: number }>
+> {
   const types: ProjectType[] = ['game-engine', 'compiler', 'web-app', 'mobile', 'generic'];
   const result: Array<{ type: ProjectType; agentCount: number }> = [];
 

--- a/src/core/complexity-detector.ts
+++ b/src/core/complexity-detector.ts
@@ -43,41 +43,84 @@ export interface ComplexityAssessment {
 // ── LOC Estimation ──────────────────────────────────────────────────────
 
 const CODE_EXTENSIONS = new Set([
-  '.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs',
-  '.py', '.pyx',
+  '.ts',
+  '.tsx',
+  '.js',
+  '.jsx',
+  '.mjs',
+  '.cjs',
+  '.py',
+  '.pyx',
   '.rs',
   '.go',
-  '.java', '.kt', '.scala',
+  '.java',
+  '.kt',
+  '.scala',
   '.cs',
-  '.cpp', '.cc', '.cxx', '.c', '.h', '.hpp',
-  '.swift', '.m', '.mm',
+  '.cpp',
+  '.cc',
+  '.cxx',
+  '.c',
+  '.h',
+  '.hpp',
+  '.swift',
+  '.m',
+  '.mm',
   '.rb',
   '.php',
-  '.ex', '.exs',
-  '.erl', '.hrl',
+  '.ex',
+  '.exs',
+  '.erl',
+  '.hrl',
   '.zig',
   '.sol',
   '.dart',
-  '.r', '.R',
+  '.r',
+  '.R',
   '.hs',
   '.lua',
-  '.hlsl', '.glsl', '.msl', '.wgsl',
+  '.hlsl',
+  '.glsl',
+  '.msl',
+  '.wgsl',
   '.sql',
-  '.sh', '.bash', '.zsh',
+  '.sh',
+  '.bash',
+  '.zsh',
 ]);
 
 const IGNORE_DIRS = new Set([
-  'node_modules', '.git', 'dist', 'build', 'out', '.next', '.nuxt',
-  'target', 'vendor', '__pycache__', '.venv', 'venv', 'env',
-  '.rulebook', '.claude', '.cursor', 'coverage', '.cache',
-  'zig-cache', 'zig-out', '.zig-cache',
+  'node_modules',
+  '.git',
+  'dist',
+  'build',
+  'out',
+  '.next',
+  '.nuxt',
+  'target',
+  'vendor',
+  '__pycache__',
+  '.venv',
+  'venv',
+  'env',
+  '.rulebook',
+  '.claude',
+  '.cursor',
+  'coverage',
+  '.cache',
+  'zig-cache',
+  'zig-out',
+  '.zig-cache',
 ]);
 
 /**
  * Estimate lines of code by sampling files. Scans up to maxFiles to avoid
  * blocking on huge repos.
  */
-function estimateLoc(projectRoot: string, maxFiles: number = 500): { loc: number; languages: Set<string> } {
+function estimateLoc(
+  projectRoot: string,
+  maxFiles: number = 500
+): { loc: number; languages: Set<string> } {
   let totalLoc = 0;
   let filesScanned = 0;
   const languages = new Set<string>();
@@ -179,9 +222,26 @@ function countCodeFiles(projectRoot: string, max: number): number {
 // ── Source Directory Count ───────────────────────────────────────────────
 
 function countSourceDirs(projectRoot: string): number {
-  const srcDirs = ['src', 'lib', 'app', 'pages', 'components', 'modules',
-    'packages', 'crates', 'cmd', 'pkg', 'internal', 'runtime',
-    'compiler', 'engine', 'core', 'server', 'client', 'api'];
+  const srcDirs = [
+    'src',
+    'lib',
+    'app',
+    'pages',
+    'components',
+    'modules',
+    'packages',
+    'crates',
+    'cmd',
+    'pkg',
+    'internal',
+    'runtime',
+    'compiler',
+    'engine',
+    'core',
+    'server',
+    'client',
+    'api',
+  ];
 
   let count = 0;
   for (const dir of srcDirs) {
@@ -196,29 +256,47 @@ function detectTools(projectRoot: string): string[] {
   const tools: string[] = [];
   if (existsSync(join(projectRoot, '.claude')) || existsSync(join(projectRoot, 'CLAUDE.md')))
     tools.push('claude-code');
-  if (existsSync(join(projectRoot, '.cursor')))
-    tools.push('cursor');
-  if (existsSync(join(projectRoot, 'GEMINI.md')))
-    tools.push('gemini');
+  if (existsSync(join(projectRoot, '.cursor'))) tools.push('cursor');
+  if (existsSync(join(projectRoot, 'GEMINI.md'))) tools.push('gemini');
   if (existsSync(join(projectRoot, '.windsurf')) || existsSync(join(projectRoot, '.windsurfrules')))
     tools.push('windsurf');
-  if (existsSync(join(projectRoot, '.github', 'copilot-instructions.md')))
-    tools.push('copilot');
-  if (existsSync(join(projectRoot, '.continue')))
-    tools.push('continue');
+  if (existsSync(join(projectRoot, '.github', 'copilot-instructions.md'))) tools.push('copilot');
+  if (existsSync(join(projectRoot, '.continue'))) tools.push('continue');
   return tools;
 }
 
 // ── Main Assessment ─────────────────────────────────────────────────────
 
 const EXT_TO_LANGUAGE: Record<string, string> = {
-  '.ts': 'TypeScript', '.tsx': 'TypeScript', '.js': 'JavaScript', '.jsx': 'JavaScript',
-  '.py': 'Python', '.rs': 'Rust', '.go': 'Go', '.java': 'Java', '.kt': 'Kotlin',
-  '.cs': 'C#', '.cpp': 'C++', '.c': 'C', '.h': 'C/C++', '.hpp': 'C++',
-  '.swift': 'Swift', '.rb': 'Ruby', '.php': 'PHP', '.dart': 'Dart',
-  '.hlsl': 'HLSL', '.glsl': 'GLSL', '.lua': 'Lua', '.zig': 'Zig',
-  '.ex': 'Elixir', '.erl': 'Erlang', '.sol': 'Solidity', '.hs': 'Haskell',
-  '.scala': 'Scala', '.r': 'R', '.R': 'R',
+  '.ts': 'TypeScript',
+  '.tsx': 'TypeScript',
+  '.js': 'JavaScript',
+  '.jsx': 'JavaScript',
+  '.py': 'Python',
+  '.rs': 'Rust',
+  '.go': 'Go',
+  '.java': 'Java',
+  '.kt': 'Kotlin',
+  '.cs': 'C#',
+  '.cpp': 'C++',
+  '.c': 'C',
+  '.h': 'C/C++',
+  '.hpp': 'C++',
+  '.swift': 'Swift',
+  '.rb': 'Ruby',
+  '.php': 'PHP',
+  '.dart': 'Dart',
+  '.hlsl': 'HLSL',
+  '.glsl': 'GLSL',
+  '.lua': 'Lua',
+  '.zig': 'Zig',
+  '.ex': 'Elixir',
+  '.erl': 'Erlang',
+  '.sol': 'Solidity',
+  '.hs': 'Haskell',
+  '.scala': 'Scala',
+  '.r': 'R',
+  '.R': 'R',
 };
 
 export function assessComplexity(projectRoot: string): ComplexityAssessment {
@@ -232,12 +310,13 @@ export function assessComplexity(projectRoot: string): ComplexityAssessment {
 
   const sourceDirectories = countSourceDirs(projectRoot);
   const hasMultipleBuildTargets =
-    existsSync(join(projectRoot, 'Cargo.toml')) && existsSync(join(projectRoot, 'package.json')) ||
-    existsSync(join(projectRoot, 'CMakeLists.txt')) && existsSync(join(projectRoot, 'package.json')) ||
-    existsSync(join(projectRoot, 'build.zig')) && existsSync(join(projectRoot, 'package.json'));
+    (existsSync(join(projectRoot, 'Cargo.toml')) &&
+      existsSync(join(projectRoot, 'package.json'))) ||
+    (existsSync(join(projectRoot, 'CMakeLists.txt')) &&
+      existsSync(join(projectRoot, 'package.json'))) ||
+    (existsSync(join(projectRoot, 'build.zig')) && existsSync(join(projectRoot, 'package.json')));
   const hasCustomMcpServer =
-    existsSync(join(projectRoot, '.mcp.json')) ||
-    existsSync(join(projectRoot, 'mcp.json'));
+    existsSync(join(projectRoot, '.mcp.json')) || existsSync(join(projectRoot, 'mcp.json'));
   const hasReferenceSource = false; // Detected from config, not file system
 
   const detectedTools = detectTools(projectRoot);

--- a/src/core/decision-manager.ts
+++ b/src/core/decision-manager.ts
@@ -1,9 +1,6 @@
 import { existsSync, mkdirSync, readdirSync } from 'fs';
 import { join } from 'path';
-import {
-  readFile as readFileUtil,
-  writeFile as writeFileUtil,
-} from '../utils/file-system.js';
+import { readFile as readFileUtil, writeFile as writeFileUtil } from '../utils/file-system.js';
 import type { Decision, DecisionStatus } from '../types.js';
 
 const DECISIONS_DIR = 'decisions';
@@ -138,7 +135,9 @@ export class DecisionManager {
 
   async update(
     id: number,
-    fields: Partial<Pick<Decision, 'status' | 'context' | 'decision' | 'consequences' | 'alternatives'>>
+    fields: Partial<
+      Pick<Decision, 'status' | 'context' | 'decision' | 'consequences' | 'alternatives'>
+    >
   ): Promise<Decision | null> {
     const result = await this.show(id);
     if (!result) return null;
@@ -212,19 +211,16 @@ export class DecisionManager {
     ];
     for (const d of active) {
       const prefix = `${pad(d.id)}-${d.slug}`;
-      lines.push(`- **ADR-${pad(d.id)}: ${d.title}** (${d.status}) → [details](/.rulebook/decisions/${prefix}.md)`);
+      lines.push(
+        `- **ADR-${pad(d.id)}: ${d.title}** (${d.status}) → [details](/.rulebook/decisions/${prefix}.md)`
+      );
     }
     lines.push('');
     return lines.join('\n');
   }
 
   private renderMarkdown(d: Decision): string {
-    const lines = [
-      `# ${d.id}. ${d.title}`,
-      '',
-      `**Status**: ${d.status}`,
-      `**Date**: ${d.date}`,
-    ];
+    const lines = [`# ${d.id}. ${d.title}`, '', `**Status**: ${d.status}`, `**Date**: ${d.date}`];
 
     if (d.relatedTasks && d.relatedTasks.length > 0) {
       lines.push(`**Related Tasks**: ${d.relatedTasks.join(', ')}`);

--- a/src/core/generator.ts
+++ b/src/core/generator.ts
@@ -190,9 +190,7 @@ export async function generateAgentsContent(config: ProjectConfig): Promise<stri
   );
 
   // RULEBOOK.md is second (task management)
-  sections.push(
-    `- \`/${rulebookDir}/specs/RULEBOOK.md\` - **Task management rules**`
-  );
+  sections.push(`- \`/${rulebookDir}/specs/RULEBOOK.md\` - **Task management rules**`);
 
   // Only reference QUALITY_ENFORCEMENT if not in light mode
   if (!config.lightMode) {
@@ -206,7 +204,9 @@ export async function generateAgentsContent(config: ProjectConfig): Promise<stri
 
   // Token optimization reference
   if (!config.lightMode) {
-    sections.push(`- \`/${rulebookDir}/specs/TOKEN_OPTIMIZATION.md\` - Model tier assignment and output verbosity rules`);
+    sections.push(
+      `- \`/${rulebookDir}/specs/TOKEN_OPTIMIZATION.md\` - Model tier assignment and output verbosity rules`
+    );
   }
 
   // Reference PLANS.md for session continuity
@@ -1039,7 +1039,12 @@ export async function generateModularAgents(
   if (!mergedConfig.lightMode) {
     const tokenOptContent = await generateCoreRules('TOKEN_OPTIMIZATION');
     if (tokenOptContent.trim()) {
-      await writeModularFile(projectRoot, 'TOKEN_OPTIMIZATION', tokenOptContent.trim(), rulebookDir);
+      await writeModularFile(
+        projectRoot,
+        'TOKEN_OPTIMIZATION',
+        tokenOptContent.trim(),
+        rulebookDir
+      );
     }
   }
 

--- a/src/core/indexer/background-indexer.ts
+++ b/src/core/indexer/background-indexer.ts
@@ -7,10 +7,24 @@ import type { IndexerConfig } from './indexer-types.js';
 
 // Binary/asset extensions to skip at the watcher level
 const IGNORED_EXTENSIONS = new Set([
-  '.png', '.jpg', '.jpeg', '.gif', '.svg', '.ico',
-  '.mp3', '.mp4', '.pdf', '.lock',
-  '.sqlite', '.sqlite-wal', '.sqlite-shm', '.sqlite-journal',
-  '.db', '.db-wal', '.db-shm', '.db-journal',
+  '.png',
+  '.jpg',
+  '.jpeg',
+  '.gif',
+  '.svg',
+  '.ico',
+  '.mp3',
+  '.mp4',
+  '.pdf',
+  '.lock',
+  '.sqlite',
+  '.sqlite-wal',
+  '.sqlite-shm',
+  '.sqlite-journal',
+  '.db',
+  '.db-wal',
+  '.db-shm',
+  '.db-journal',
 ]);
 
 export class BackgroundIndexer {
@@ -59,8 +73,8 @@ export class BackgroundIndexer {
 
     // Resolve watch paths to absolute, filtering to those that actually exist
     const watchTargets = this.config.watchPaths
-      .map(p => (p === '.' ? this.projectRoot : resolve(this.projectRoot, p)))
-      .filter(p => existsSync(p));
+      .map((p) => (p === '.' ? this.projectRoot : resolve(this.projectRoot, p)))
+      .filter((p) => existsSync(p));
 
     if (watchTargets.length === 0) {
       console.error('[BackgroundIndexer] No valid watch paths found, falling back to project root');
@@ -144,13 +158,45 @@ export class BackgroundIndexer {
   private isCodeFile(filePath: string): boolean {
     const ext = extname(filePath).toLowerCase();
     const codeExts = [
-      '.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs',
-      '.py', '.rs', '.go', '.java', '.kt', '.scala',
-      '.cs', '.cpp', '.cc', '.c', '.h', '.hpp',
-      '.swift', '.rb', '.php', '.ex', '.erl', '.zig',
-      '.sol', '.dart', '.lua', '.hs', '.r', '.R',
-      '.sh', '.bash', '.zsh', '.yaml', '.yml', '.json',
-      '.toml', '.md', '.mdx',
+      '.ts',
+      '.tsx',
+      '.js',
+      '.jsx',
+      '.mjs',
+      '.cjs',
+      '.py',
+      '.rs',
+      '.go',
+      '.java',
+      '.kt',
+      '.scala',
+      '.cs',
+      '.cpp',
+      '.cc',
+      '.c',
+      '.h',
+      '.hpp',
+      '.swift',
+      '.rb',
+      '.php',
+      '.ex',
+      '.erl',
+      '.zig',
+      '.sol',
+      '.dart',
+      '.lua',
+      '.hs',
+      '.r',
+      '.R',
+      '.sh',
+      '.bash',
+      '.zsh',
+      '.yaml',
+      '.yml',
+      '.json',
+      '.toml',
+      '.md',
+      '.mdx',
     ];
     return codeExts.includes(ext);
   }

--- a/src/core/indexer/background-indexer.ts
+++ b/src/core/indexer/background-indexer.ts
@@ -1,9 +1,17 @@
-import { existsSync, statSync } from 'fs';
-import { extname, resolve } from 'path';
+import { existsSync, statSync, type Stats } from 'fs';
+import { basename, extname, resolve } from 'path';
 import chokidar, { type FSWatcher } from 'chokidar';
 import type { MemoryManager } from '../../memory/memory-manager.js';
 import { CodeParser } from './file-parser.js';
 import type { IndexerConfig } from './indexer-types.js';
+
+// Binary/asset extensions to skip at the watcher level
+const IGNORED_EXTENSIONS = new Set([
+  '.png', '.jpg', '.jpeg', '.gif', '.svg', '.ico',
+  '.mp3', '.mp4', '.pdf', '.lock',
+  '.sqlite', '.sqlite-wal', '.sqlite-shm', '.sqlite-journal',
+  '.db', '.db-wal', '.db-shm', '.db-journal',
+]);
 
 export class BackgroundIndexer {
   private memoryManager: MemoryManager;
@@ -14,6 +22,7 @@ export class BackgroundIndexer {
   private processQueue: Set<string> = new Set();
   private debounceTimer: NodeJS.Timeout | null = null;
   private watcher: FSWatcher | null = null;
+  private hasRetriedWithPolling = false;
 
   // Stats
   private processedCount = 0;
@@ -40,31 +49,54 @@ export class BackgroundIndexer {
       ],
       chunkSize: config.chunkSize ?? 1500,
       debounceMs: config.debounceMs ?? 3000,
+      depth: config.depth ?? 4,
+      usePolling: config.usePolling ?? false,
     };
   }
 
   public start(): void {
     if (!this.config.enabled) return;
-    console.error(`[BackgroundIndexer] Starting watcher on: ${this.projectRoot}`);
 
-    // Use chokidar for reliable cross-platform file watching with proper ignore support.
-    // Unlike fs.watch({ recursive: true }), chokidar filters at the OS watcher level,
-    // preventing node_modules events from ever reaching the event loop.
-    const ignoredGlobs = this.config.ignorePatterns.map(p => `**/${p}/**`);
-    // Also ignore binary/asset files at the watcher level
-    ignoredGlobs.push(
-      '**/*.png', '**/*.jpg', '**/*.jpeg', '**/*.gif', '**/*.svg', '**/*.ico',
-      '**/*.mp3', '**/*.mp4', '**/*.pdf', '**/*.lock',
-      '**/*.sqlite', '**/*.sqlite-wal', '**/*.sqlite-shm', '**/*.sqlite-journal',
-      '**/*.db', '**/*.db-wal', '**/*.db-shm', '**/*.db-journal',
-    );
+    // Resolve watch paths to absolute, filtering to those that actually exist
+    const watchTargets = this.config.watchPaths
+      .map(p => (p === '.' ? this.projectRoot : resolve(this.projectRoot, p)))
+      .filter(p => existsSync(p));
 
-    this.watcher = chokidar.watch(this.projectRoot, {
-      ignored: ignoredGlobs,
+    if (watchTargets.length === 0) {
+      console.error('[BackgroundIndexer] No valid watch paths found, falling back to project root');
+      watchTargets.push(this.projectRoot);
+    }
+
+    console.error(`[BackgroundIndexer] Starting watcher on: ${watchTargets.join(', ')}`);
+
+    // Build a Set for O(1) directory-name lookups
+    const ignoredDirNames = new Set(this.config.ignorePatterns);
+
+    // Function-based ignored: prevents chokidar from ENTERING ignored directories.
+    // Unlike glob strings (e.g. '**/node_modules/**'), a function-based filter stops
+    // chokidar from opening file descriptors for ignored directories at all.
+    const ignoredFn = (filePath: string, stats?: Stats): boolean => {
+      const base = basename(filePath);
+      // Block traversal into ignored directories
+      if (ignoredDirNames.has(base)) {
+        // When stats are available, only block directories (not files named 'dist' etc.)
+        if (stats) return stats.isDirectory();
+        return true;
+      }
+      // Skip binary/asset files by extension
+      if (IGNORED_EXTENSIONS.has(extname(base).toLowerCase())) {
+        return true;
+      }
+      return false;
+    };
+
+    this.watcher = chokidar.watch(watchTargets, {
+      ignored: ignoredFn,
       persistent: true,
       ignoreInitial: true,
-      depth: 8,
-      // Reduce CPU usage: aggregate events over 500ms
+      depth: this.config.depth,
+      usePolling: this.config.usePolling,
+      ...(this.config.usePolling ? { interval: 2000 } : {}),
       awaitWriteFinish: {
         stabilityThreshold: 500,
         pollInterval: 100,
@@ -76,6 +108,17 @@ export class BackgroundIndexer {
       .on('add', (filePath: string) => this.handleFileChange(filePath))
       .on('unlink', (filePath: string) => this.handleFileChange(filePath))
       .on('error', (error: unknown) => {
+        const errCode = (error as NodeJS.ErrnoException)?.code;
+        if ((errCode === 'EMFILE' || errCode === 'ENFILE') && !this.hasRetriedWithPolling) {
+          console.error(
+            '[BackgroundIndexer] Too many open files detected. Restarting with polling mode...'
+          );
+          this.hasRetriedWithPolling = true;
+          this.stop();
+          this.config.usePolling = true;
+          this.start();
+          return;
+        }
         console.error('[BackgroundIndexer] Watcher error:', error);
       });
   }

--- a/src/core/indexer/indexer-types.ts
+++ b/src/core/indexer/indexer-types.ts
@@ -43,4 +43,6 @@ export interface IndexerConfig {
   ignorePatterns: string[]; // e.g., ['node_modules', 'dist']
   chunkSize: number; // Default rough characters per chunk if AST fails
   debounceMs: number; // Default 3000ms
+  depth: number; // Max directory depth for file watching (default: 4)
+  usePolling: boolean; // Fallback to polling for FD-constrained envs (default: false)
 }

--- a/src/core/knowledge-manager.ts
+++ b/src/core/knowledge-manager.ts
@@ -1,9 +1,6 @@
 import { existsSync, mkdirSync, readdirSync, rmSync } from 'fs';
 import { join } from 'path';
-import {
-  readFile as readFileUtil,
-  writeFile as writeFileUtil,
-} from '../utils/file-system.js';
+import { readFile as readFileUtil, writeFile as writeFileUtil } from '../utils/file-system.js';
 import type { KnowledgeEntry, KnowledgeType, KnowledgeCategory } from '../types.js';
 
 const KNOWLEDGE_DIR = 'knowledge';
@@ -157,9 +154,7 @@ export class KnowledgeManager {
     if (patterns.length > 0) {
       lines.push('### Patterns', '', 'The following patterns are enforced in this project:', '');
       for (const p of patterns) {
-        lines.push(
-          `- **${p.title}** → [spec](/.rulebook/knowledge/patterns/${p.id}.md)`
-        );
+        lines.push(`- **${p.title}** → [spec](/.rulebook/knowledge/patterns/${p.id}.md)`);
       }
       lines.push('');
     }
@@ -167,9 +162,7 @@ export class KnowledgeManager {
     if (antiPatterns.length > 0) {
       lines.push('### Anti-Patterns to Avoid', '');
       for (const a of antiPatterns) {
-        lines.push(
-          `- **${a.title}** → [details](/.rulebook/knowledge/anti-patterns/${a.id}.md)`
-        );
+        lines.push(`- **${a.title}** → [details](/.rulebook/knowledge/anti-patterns/${a.id}.md)`);
       }
       lines.push('');
     }

--- a/src/core/learn-manager.ts
+++ b/src/core/learn-manager.ts
@@ -1,9 +1,6 @@
 import { existsSync, mkdirSync, readdirSync } from 'fs';
 import { join } from 'path';
-import {
-  readFile as readFileUtil,
-  writeFile as writeFileUtil,
-} from '../utils/file-system.js';
+import { readFile as readFileUtil, writeFile as writeFileUtil } from '../utils/file-system.js';
 import type { Learning, KnowledgeCategory } from '../types.js';
 import { DecisionManager } from './decision-manager.js';
 import { KnowledgeManager } from './knowledge-manager.js';
@@ -92,8 +89,8 @@ export class LearnManager {
     this.ensureDir();
     if (!existsSync(this.ralphHistoryPath)) return [];
 
-    const files = readdirSync(this.ralphHistoryPath).filter((f) =>
-      f.startsWith('iteration-') && f.endsWith('.json')
+    const files = readdirSync(this.ralphHistoryPath).filter(
+      (f) => f.startsWith('iteration-') && f.endsWith('.json')
     );
 
     // Load existing learning titles for dedup

--- a/src/core/rule-engine.ts
+++ b/src/core/rule-engine.ts
@@ -137,10 +137,7 @@ function shouldTarget(rule: CanonicalRule, tool: ToolTarget): boolean {
  * Project rules to Claude Code format: `.claude/rules/<name>.md`
  * Claude Code rules are plain markdown — no special frontmatter.
  */
-async function projectToClaudeCode(
-  projectRoot: string,
-  rules: CanonicalRule[]
-): Promise<string[]> {
+async function projectToClaudeCode(projectRoot: string, rules: CanonicalRule[]): Promise<string[]> {
   const targetRules = rules.filter((r) => shouldTarget(r, 'claude-code'));
   if (targetRules.length === 0) return [];
 
@@ -161,10 +158,7 @@ async function projectToClaudeCode(
  * Project rules to Cursor format: `.cursor/rules/<name>.mdc`
  * Cursor uses YAML frontmatter with `description`, `alwaysApply`, and `globs`.
  */
-async function projectToCursor(
-  projectRoot: string,
-  rules: CanonicalRule[]
-): Promise<string[]> {
+async function projectToCursor(projectRoot: string, rules: CanonicalRule[]): Promise<string[]> {
   const targetRules = rules.filter((r) => shouldTarget(r, 'cursor'));
   if (targetRules.length === 0) return [];
 
@@ -195,10 +189,7 @@ async function projectToCursor(
  * Project rules to Gemini format: sections in `GEMINI.md`.
  * Groups rules by tier with appropriate headings.
  */
-async function projectToGemini(
-  projectRoot: string,
-  rules: CanonicalRule[]
-): Promise<string[]> {
+async function projectToGemini(projectRoot: string, rules: CanonicalRule[]): Promise<string[]> {
   const targetRules = rules.filter((r) => shouldTarget(r, 'gemini'));
   if (targetRules.length === 0) return [];
 
@@ -257,10 +248,7 @@ async function projectToGemini(
 /**
  * Project rules to Copilot format: sections in `.github/copilot-instructions.md`.
  */
-async function projectToCopilot(
-  projectRoot: string,
-  rules: CanonicalRule[]
-): Promise<string[]> {
+async function projectToCopilot(projectRoot: string, rules: CanonicalRule[]): Promise<string[]> {
   const targetRules = rules.filter((r) => shouldTarget(r, 'copilot'));
   if (targetRules.length === 0) return [];
 
@@ -308,10 +296,7 @@ async function projectToCopilot(
 /**
  * Project rules to Windsurf format: `.windsurf/rules/<name>.md`
  */
-async function projectToWindsurf(
-  projectRoot: string,
-  rules: CanonicalRule[]
-): Promise<string[]> {
+async function projectToWindsurf(projectRoot: string, rules: CanonicalRule[]): Promise<string[]> {
   const targetRules = rules.filter((r) => shouldTarget(r, 'windsurf'));
   if (targetRules.length === 0) return [];
 
@@ -389,9 +374,7 @@ export async function projectRules(
     gemini: detectedTools.gemini ? await projectToGemini(projectRoot, rules) : [],
     copilot: detectedTools.copilot ? await projectToCopilot(projectRoot, rules) : [],
     windsurf: detectedTools.windsurf ? await projectToWindsurf(projectRoot, rules) : [],
-    continueDev: detectedTools.continueDev
-      ? await projectToContinueDev(projectRoot, rules)
-      : [],
+    continueDev: detectedTools.continueDev ? await projectToContinueDev(projectRoot, rules) : [],
   };
 
   return result;

--- a/src/core/task-manager.ts
+++ b/src/core/task-manager.ts
@@ -392,9 +392,7 @@ export class TaskManager {
   /**
    * Get raw task metadata (including blocks/blockedBy/cascadeImpact for v5 blocker tracking)
    */
-  async getTaskMetadata(
-    taskId: string
-  ): Promise<Record<string, unknown> | null> {
+  async getTaskMetadata(taskId: string): Promise<Record<string, unknown> | null> {
     const taskPath = join(this.tasksPath, taskId);
     const metadataPath = join(taskPath, '.metadata.json');
     if (!(await fileExists(metadataPath))) return null;

--- a/src/index.ts
+++ b/src/index.ts
@@ -114,7 +114,10 @@ program
   .option('--lean', 'Lean mode: AGENTS.md is a lightweight index (<3KB) referencing spec files')
   .option('--package <name>', 'Initialize only a single package inside a monorepo')
   .option('--add-sequential-thinking', 'Auto-add sequential-thinking MCP to .mcp.json')
-  .option('--tools <tools>', 'Comma-separated AI tools to generate for (e.g., claude-code,cursor,gemini)')
+  .option(
+    '--tools <tools>',
+    'Comma-separated AI tools to generate for (e.g., claude-code,cursor,gemini)'
+  )
   .action(initCommand);
 
 program
@@ -282,15 +285,26 @@ taskCommand
     }
 
     if (blockers.length === 0) {
-      console.log(chalk.gray('No blocker chains found. Add "blocks" field to task .metadata.json to track dependencies.'));
+      console.log(
+        chalk.gray(
+          'No blocker chains found. Add "blocks" field to task .metadata.json to track dependencies.'
+        )
+      );
       return;
     }
 
     blockers.sort((a, b) => b.cascadeImpact - a.cascadeImpact);
     console.log(chalk.bold('\nBlocker Chain (highest cascade impact first)\n'));
     for (const b of blockers) {
-      const impact = b.cascadeImpact >= 3 ? chalk.red('HIGH') : b.cascadeImpact >= 2 ? chalk.yellow('MEDIUM') : chalk.gray('LOW');
-      console.log(`  ${chalk.green(b.taskId)} → blocks: ${b.blocks.join(', ')} (${b.cascadeImpact} tasks, ${impact} impact)`);
+      const impact =
+        b.cascadeImpact >= 3
+          ? chalk.red('HIGH')
+          : b.cascadeImpact >= 2
+            ? chalk.yellow('MEDIUM')
+            : chalk.gray('LOW');
+      console.log(
+        `  ${chalk.green(b.taskId)} → blocks: ${b.blocks.join(', ')} (${b.cascadeImpact} tasks, ${impact} impact)`
+      );
     }
     console.log('');
   });
@@ -312,7 +326,7 @@ taskCommand
       console.log(chalk.yellow(`Task "${taskId}" not found or has no metadata.`));
       return;
     }
-    const blockedBy = Array.isArray(metadata.blockedBy) ? metadata.blockedBy as string[] : [];
+    const blockedBy = Array.isArray(metadata.blockedBy) ? (metadata.blockedBy as string[]) : [];
     if (blockedBy.length === 0) {
       console.log(chalk.green(`Task "${taskId}" is not blocked by anything.`));
     } else {
@@ -346,7 +360,10 @@ program
   .option('--minimal', 'Regenerate using minimal mode (essentials only)')
   .option('--light', 'Light mode: bare minimum rules (no tests, no linting)')
   .option('--lean', 'Lean mode: AGENTS.md is a lightweight index (<3KB) referencing spec files')
-  .option('--tools <tools>', 'Comma-separated AI tools to generate for (e.g., claude-code,cursor,gemini)')
+  .option(
+    '--tools <tools>',
+    'Comma-separated AI tools to generate for (e.g., claude-code,cursor,gemini)'
+  )
   .action(updateCommand);
 
 // MCP commands
@@ -632,7 +649,9 @@ workspaceCommand
   .action(() => workspaceStatusCommand());
 
 // Context Intelligence commands (v4.4)
-const decisionCommand = program.command('decision').description('Manage Architecture Decision Records');
+const decisionCommand = program
+  .command('decision')
+  .description('Manage Architecture Decision Records');
 
 decisionCommand
   .command('create <title>')
@@ -664,7 +683,11 @@ const knowledgeCommand = program.command('knowledge').description('Manage projec
 knowledgeCommand
   .command('add <type> <title>')
   .description('Add a pattern or anti-pattern')
-  .option('--category <category>', 'Category: architecture, code, testing, security, performance, devops', 'code')
+  .option(
+    '--category <category>',
+    'Category: architecture, code, testing, security, performance, devops',
+    'code'
+  )
   .option('--description <desc>', 'Description of the pattern')
   .action((type: string, title: string, options: { category?: string; description?: string }) =>
     knowledgeAddCommand(type, title, options)
@@ -732,7 +755,9 @@ program
 
     const spinner = ora('Analyzing project complexity...').start();
     const result = assessComplexity(cwd);
-    spinner.succeed(`Project complexity: ${result.tier.toUpperCase()} (score: ${result.score}/100)`);
+    spinner.succeed(
+      `Project complexity: ${result.tier.toUpperCase()} (score: ${result.score}/100)`
+    );
 
     console.log(chalk.bold('\nMetrics'));
     console.log(`  Estimated LOC:      ${result.metrics.estimatedLoc.toLocaleString()}`);
@@ -747,19 +772,35 @@ program
 
     console.log(chalk.bold('\nRecommended Configuration'));
     const rec = result.recommendations;
-    console.log(`  ${rec.tier1Rules ? chalk.green('✓') : chalk.gray('·')} Tier 1 prohibitions (no-shortcuts, git-safety, etc.)`);
-    console.log(`  ${rec.tier2Rules ? chalk.green('✓') : chalk.gray('·')} Tier 2 workflow rules (decomposition, incremental tests)`);
-    console.log(`  ${rec.specializedAgents ? chalk.green('✓') : chalk.gray('·')} Specialized agents by project type`);
-    console.log(`  ${rec.teamCoordination ? chalk.green('✓') : chalk.gray('·')} Multi-agent team coordination`);
-    console.log(`  ${rec.blockerTracking ? chalk.green('✓') : chalk.gray('·')} Task blocker chain tracking`);
-    console.log(`  ${rec.dataFlowPlanning ? chalk.green('✓') : chalk.gray('·')} Data flow planning for cross-subsystem changes`);
-    console.log(`  ${rec.referenceWorkflow ? chalk.green('✓') : chalk.gray('·')} Reference implementation workflow`);
+    console.log(
+      `  ${rec.tier1Rules ? chalk.green('✓') : chalk.gray('·')} Tier 1 prohibitions (no-shortcuts, git-safety, etc.)`
+    );
+    console.log(
+      `  ${rec.tier2Rules ? chalk.green('✓') : chalk.gray('·')} Tier 2 workflow rules (decomposition, incremental tests)`
+    );
+    console.log(
+      `  ${rec.specializedAgents ? chalk.green('✓') : chalk.gray('·')} Specialized agents by project type`
+    );
+    console.log(
+      `  ${rec.teamCoordination ? chalk.green('✓') : chalk.gray('·')} Multi-agent team coordination`
+    );
+    console.log(
+      `  ${rec.blockerTracking ? chalk.green('✓') : chalk.gray('·')} Task blocker chain tracking`
+    );
+    console.log(
+      `  ${rec.dataFlowPlanning ? chalk.green('✓') : chalk.gray('·')} Data flow planning for cross-subsystem changes`
+    );
+    console.log(
+      `  ${rec.referenceWorkflow ? chalk.green('✓') : chalk.gray('·')} Reference implementation workflow`
+    );
     console.log('');
   });
 
 // ── Rules Management (v5.0) ─────────────────────────────────────────────
 
-const rulesCommand = program.command('rules').description('Manage canonical rules (.rulebook/rules/)');
+const rulesCommand = program
+  .command('rules')
+  .description('Manage canonical rules (.rulebook/rules/)');
 
 rulesCommand
   .command('list')
@@ -773,9 +814,13 @@ rulesCommand
       console.log(chalk.gray('Run "rulebook rules add <name>" to install from template library'));
       return;
     }
-    const tierLabels: Record<number, string> = { 1: 'Tier 1 (Prohibition)', 2: 'Tier 2 (Workflow)', 3: 'Tier 3 (Standard)' };
+    const tierLabels: Record<number, string> = {
+      1: 'Tier 1 (Prohibition)',
+      2: 'Tier 2 (Workflow)',
+      3: 'Tier 3 (Standard)',
+    };
     for (const tier of [1, 2, 3]) {
-      const tierRules = rules.filter(r => r.tier === tier);
+      const tierRules = rules.filter((r) => r.tier === tier);
       if (tierRules.length === 0) continue;
       console.log(chalk.bold(`\n${tierLabels[tier]}`));
       for (const r of tierRules) {
@@ -800,7 +845,11 @@ rulesCommand
       console.log(chalk.gray('Run "rulebook update" to project rules to all detected tools'));
     } else {
       console.log(chalk.red(`✗ Rule template "${name}" not found`));
-      console.log(chalk.gray('Available: no-shortcuts, git-safety, sequential-editing, task-decomposition, research-first, incremental-tests, incremental-implementation, no-deferred, follow-task-sequence, session-workflow'));
+      console.log(
+        chalk.gray(
+          'Available: no-shortcuts, git-safety, sequential-editing, task-decomposition, research-first, incremental-tests, incremental-implementation, no-deferred, follow-task-sequence, session-workflow'
+        )
+      );
     }
   });
 
@@ -825,15 +874,24 @@ rulesCommand
       copilot: detection.githubCopilot?.detected,
       continueDev: detection.continueDev?.detected,
     });
-    const total = result.claudeCode.length + result.cursor.length + result.gemini.length +
-      result.copilot.length + result.windsurf.length + result.continueDev.length;
+    const total =
+      result.claudeCode.length +
+      result.cursor.length +
+      result.gemini.length +
+      result.copilot.length +
+      result.windsurf.length +
+      result.continueDev.length;
     spinner.succeed(`Projected rules to ${total} tool-specific files`);
-    if (result.claudeCode.length) console.log(chalk.gray(`  • Claude Code: ${result.claudeCode.length} files`));
+    if (result.claudeCode.length)
+      console.log(chalk.gray(`  • Claude Code: ${result.claudeCode.length} files`));
     if (result.cursor.length) console.log(chalk.gray(`  • Cursor: ${result.cursor.length} files`));
     if (result.gemini.length) console.log(chalk.gray(`  • Gemini: ${result.gemini.length} files`));
-    if (result.copilot.length) console.log(chalk.gray(`  • Copilot: ${result.copilot.length} files`));
-    if (result.windsurf.length) console.log(chalk.gray(`  • Windsurf: ${result.windsurf.length} files`));
-    if (result.continueDev.length) console.log(chalk.gray(`  • Continue.dev: ${result.continueDev.length} files`));
+    if (result.copilot.length)
+      console.log(chalk.gray(`  • Copilot: ${result.copilot.length} files`));
+    if (result.windsurf.length)
+      console.log(chalk.gray(`  • Windsurf: ${result.windsurf.length} files`));
+    if (result.continueDev.length)
+      console.log(chalk.gray(`  • Continue.dev: ${result.continueDev.length} files`));
   });
 
 program.parse(process.argv);

--- a/src/mcp/rulebook-server.ts
+++ b/src/mcp/rulebook-server.ts
@@ -2757,7 +2757,9 @@ export async function startRulebookMcpServer(): Promise<void> {
       description:
         'Save session summary to PLANS.md history section. Call at the end of every session.',
       inputSchema: {
-        summary: z.string().describe('Session summary: what was accomplished, key decisions, next steps'),
+        summary: z
+          .string()
+          .describe('Session summary: what was accomplished, key decisions, next steps'),
         projectId: projectIdSchema,
       },
     },
@@ -2808,7 +2810,10 @@ export async function startRulebookMcpServer(): Promise<void> {
 
         return {
           content: [
-            { type: 'text', text: JSON.stringify({ success: true, message: 'Session summary saved to PLANS.md' }) },
+            {
+              type: 'text',
+              text: JSON.stringify({ success: true, message: 'Session summary saved to PLANS.md' }),
+            },
           ],
         };
       } catch (error) {
@@ -2832,7 +2837,8 @@ export async function startRulebookMcpServer(): Promise<void> {
     'rulebook_rules_list',
     {
       title: 'List Rules',
-      description: 'List all canonical rules from .rulebook/rules/ with tier and tool targeting info',
+      description:
+        'List all canonical rules from .rulebook/rules/ with tier and tool targeting info',
       inputSchema: {
         projectId: projectIdSchema,
       },
@@ -2846,7 +2852,9 @@ export async function startRulebookMcpServer(): Promise<void> {
         const { listRules } = await import('../core/rule-engine.js');
         const rules = await listRules(root);
         return {
-          content: [{ type: 'text', text: JSON.stringify({ success: true, rules, count: rules.length }) }],
+          content: [
+            { type: 'text', text: JSON.stringify({ success: true, rules, count: rules.length }) },
+          ],
         };
       } catch (error) {
         return {
@@ -2889,8 +2897,10 @@ export async function startRulebookMcpServer(): Promise<void> {
 
         for (const task of tasks) {
           const metadata = await tm.getTaskMetadata(task.id);
-          const blocks = Array.isArray(metadata?.blocks) ? metadata.blocks as string[] : [];
-          const blockedBy = Array.isArray(metadata?.blockedBy) ? metadata.blockedBy as string[] : [];
+          const blocks = Array.isArray(metadata?.blocks) ? (metadata.blocks as string[]) : [];
+          const blockedBy = Array.isArray(metadata?.blockedBy)
+            ? (metadata.blockedBy as string[])
+            : [];
           if (blocks.length > 0 || blockedBy.length > 0) {
             blockers.push({
               taskId: task.id,

--- a/src/mcp/rulebook-server.ts
+++ b/src/mcp/rulebook-server.ts
@@ -321,7 +321,7 @@ export async function startRulebookMcpServer(): Promise<void> {
 
   const server = new McpServer({
     name: 'rulebook-task-management',
-    version: '5.1.2',
+    version: '5.1.3',
   });
 
   // --- Wrap all tool handlers with timeout guard ---
@@ -963,7 +963,10 @@ export async function startRulebookMcpServer(): Promise<void> {
         // Boot Background Indexer only if memory is enabled (opt-in to save resources)
         const indexerEnabled = rulebookConfig.memory?.enabled === true;
         if (indexerEnabled) {
-          bgIndexer = new BackgroundIndexer(memoryManager, projectRoot, { enabled: true });
+          bgIndexer = new BackgroundIndexer(memoryManager, projectRoot, {
+            enabled: true,
+            ...rulebookConfig.indexer,
+          });
           setTimeout(() => {
             try {
               bgIndexer?.start();

--- a/src/memory/hnsw-index.ts
+++ b/src/memory/hnsw-index.ts
@@ -25,9 +25,13 @@ interface SearchCandidate {
 class MinHeap {
   private heap: SearchCandidate[] = [];
 
-  get size(): number { return this.heap.length; }
+  get size(): number {
+    return this.heap.length;
+  }
 
-  peek(): SearchCandidate | undefined { return this.heap[0]; }
+  peek(): SearchCandidate | undefined {
+    return this.heap[0];
+  }
 
   push(item: SearchCandidate): void {
     this.heap.push(item);
@@ -80,9 +84,13 @@ class MinHeap {
 class MaxHeap {
   private heap: SearchCandidate[] = [];
 
-  get size(): number { return this.heap.length; }
+  get size(): number {
+    return this.heap.length;
+  }
 
-  peek(): SearchCandidate | undefined { return this.heap[0]; }
+  peek(): SearchCandidate | undefined {
+    return this.heap[0];
+  }
 
   push(item: SearchCandidate): void {
     this.heap.push(item);
@@ -201,8 +209,8 @@ export class HNSWIndex {
     layer: number
   ): SearchCandidate[] {
     const visited = new Set<string>();
-    const candidates = new MinHeap();  // closest-first extraction
-    const results = new MaxHeap();     // farthest-first for boundary check
+    const candidates = new MinHeap(); // closest-first extraction
+    const results = new MaxHeap(); // farthest-first for boundary check
 
     const entryNode = this.nodes.get(entryLabel);
     if (!entryNode) return [];

--- a/src/memory/memory-store.ts
+++ b/src/memory/memory-store.ts
@@ -46,7 +46,9 @@ export class MemoryStore {
       this.db.pragma('foreign_keys = ON');
     } catch {
       // better-sqlite3 not available — fall back to sql.js (WASM)
-      console.error('[MemoryStore] better-sqlite3 unavailable, falling back to sql.js (slower but portable)');
+      console.error(
+        '[MemoryStore] better-sqlite3 unavailable, falling back to sql.js (slower but portable)'
+      );
       const { default: initSqlJs } = await import('sql.js');
       const SQL = await initSqlJs();
       let rawDb;
@@ -179,30 +181,34 @@ export class MemoryStore {
   saveMemory(memory: Memory): void {
     if (!this.db) throw new Error('Database not initialized');
 
-    this.db.prepare(
-      `INSERT OR REPLACE INTO memories (id, type, title, content, project, tags, session_id, created_at, updated_at, accessed_at)
+    this.db
+      .prepare(
+        `INSERT OR REPLACE INTO memories (id, type, title, content, project, tags, session_id, created_at, updated_at, accessed_at)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
-    ).run(
-      memory.id,
-      memory.type,
-      memory.title,
-      memory.content,
-      memory.project,
-      JSON.stringify(memory.tags),
-      memory.sessionId ?? null,
-      memory.createdAt,
-      memory.updatedAt,
-      memory.accessedAt,
-    );
+      )
+      .run(
+        memory.id,
+        memory.type,
+        memory.title,
+        memory.content,
+        memory.project,
+        JSON.stringify(memory.tags),
+        memory.sessionId ?? null,
+        memory.createdAt,
+        memory.updatedAt,
+        memory.accessedAt
+      );
   }
 
   getMemory(id: string): Memory | null {
     if (!this.db) throw new Error('Database not initialized');
 
-    const row = this.db.prepare(
-      `SELECT id, type, title, content, project, tags, session_id, created_at, updated_at, accessed_at
+    const row = this.db
+      .prepare(
+        `SELECT id, type, title, content, project, tags, session_id, created_at, updated_at, accessed_at
        FROM memories WHERE id = ?`
-    ).get(id) as Record<string, unknown> | undefined;
+      )
+      .get(id) as Record<string, unknown> | undefined;
 
     if (!row) return null;
     return this.rowToMemory(row);
@@ -237,10 +243,12 @@ export class MemoryStore {
     const limit = options?.limit ?? 100;
     const offset = options?.offset ?? 0;
 
-    const rows = this.db.prepare(
-      `SELECT id, type, title, content, project, tags, session_id, created_at, updated_at, accessed_at
+    const rows = this.db
+      .prepare(
+        `SELECT id, type, title, content, project, tags, session_id, created_at, updated_at, accessed_at
        FROM memories ${where} ORDER BY created_at DESC LIMIT ? OFFSET ?`
-    ).all(...params, limit, offset) as Array<Record<string, unknown>>;
+      )
+      .all(...params, limit, offset) as Array<Record<string, unknown>>;
 
     return rows.map((row) => this.rowToMemory(row));
   }
@@ -252,7 +260,9 @@ export class MemoryStore {
 
   getMemoryCount(): number {
     if (!this.db) throw new Error('Database not initialized');
-    const row = this.db.prepare('SELECT COUNT(*) as count FROM memories').get() as { count: number };
+    const row = this.db.prepare('SELECT COUNT(*) as count FROM memories').get() as {
+      count: number;
+    };
     return row.count;
   }
 
@@ -271,9 +281,9 @@ export class MemoryStore {
       if (!escaped) return [];
 
       // Build FTS5 match query with proper term quoting
-      const terms = escaped.split(/\s+/).filter(t => t.length > 1);
+      const terms = escaped.split(/\s+/).filter((t) => t.length > 1);
       if (terms.length === 0) return [];
-      const ftsQuery = terms.map(t => `"${t}"`).join(' OR ');
+      const ftsQuery = terms.map((t) => `"${t}"`).join(' OR ');
 
       let sql = `
         SELECT m.id, bm25(memory_fts) as score
@@ -336,34 +346,38 @@ export class MemoryStore {
   createSession(session: MemorySession): void {
     if (!this.db) throw new Error('Database not initialized');
 
-    this.db.prepare(
-      `INSERT INTO sessions (id, project, status, started_at, ended_at, summary, tool_calls)
+    this.db
+      .prepare(
+        `INSERT INTO sessions (id, project, status, started_at, ended_at, summary, tool_calls)
        VALUES (?, ?, ?, ?, ?, ?, ?)`
-    ).run(
-      session.id,
-      session.project,
-      session.status,
-      session.startedAt,
-      session.endedAt ?? null,
-      session.summary ?? null,
-      session.toolCalls,
-    );
+      )
+      .run(
+        session.id,
+        session.project,
+        session.status,
+        session.startedAt,
+        session.endedAt ?? null,
+        session.summary ?? null,
+        session.toolCalls
+      );
   }
 
   endSession(id: string, summary?: string): void {
     if (!this.db) throw new Error('Database not initialized');
-    this.db.prepare(
-      `UPDATE sessions SET status = 'completed', ended_at = ?, summary = ? WHERE id = ?`
-    ).run(Date.now(), summary ?? null, id);
+    this.db
+      .prepare(`UPDATE sessions SET status = 'completed', ended_at = ?, summary = ? WHERE id = ?`)
+      .run(Date.now(), summary ?? null, id);
   }
 
   getActiveSession(): MemorySession | null {
     if (!this.db) throw new Error('Database not initialized');
 
-    const row = this.db.prepare(
-      `SELECT id, project, status, started_at, ended_at, summary, tool_calls
+    const row = this.db
+      .prepare(
+        `SELECT id, project, status, started_at, ended_at, summary, tool_calls
        FROM sessions WHERE status = 'active' ORDER BY started_at DESC LIMIT 1`
-    ).get() as Record<string, unknown> | undefined;
+      )
+      .get() as Record<string, unknown> | undefined;
 
     if (!row) return null;
 
@@ -380,7 +394,9 @@ export class MemoryStore {
 
   getSessionCount(): number {
     if (!this.db) throw new Error('Database not initialized');
-    const row = this.db.prepare('SELECT COUNT(*) as count FROM sessions').get() as { count: number };
+    const row = this.db.prepare('SELECT COUNT(*) as count FROM sessions').get() as {
+      count: number;
+    };
     return row.count;
   }
 
@@ -388,13 +404,17 @@ export class MemoryStore {
 
   getOldestMemoryTimestamp(): number | undefined {
     if (!this.db) return undefined;
-    const row = this.db.prepare('SELECT MIN(created_at) as ts FROM memories').get() as { ts: number | null };
+    const row = this.db.prepare('SELECT MIN(created_at) as ts FROM memories').get() as {
+      ts: number | null;
+    };
     return row.ts ?? undefined;
   }
 
   getNewestMemoryTimestamp(): number | undefined {
     if (!this.db) return undefined;
-    const row = this.db.prepare('SELECT MAX(created_at) as ts FROM memories').get() as { ts: number | null };
+    const row = this.db.prepare('SELECT MAX(created_at) as ts FROM memories').get() as {
+      ts: number | null;
+    };
     return row.ts ?? undefined;
   }
 
@@ -424,16 +444,17 @@ export class MemoryStore {
     if (!this.db) return [];
 
     // Get anchor memory's timestamp
-    const anchor = this.db.prepare(
-      `SELECT created_at FROM memories WHERE id = ?`
-    ).get(memoryId) as { created_at: number } | undefined;
+    const anchor = this.db.prepare(`SELECT created_at FROM memories WHERE id = ?`).get(memoryId) as
+      | { created_at: number }
+      | undefined;
 
     if (!anchor) return [];
     const anchorTs = anchor.created_at;
 
     // Get before + anchor + after
-    const rows = this.db.prepare(
-      `SELECT id, title, type, created_at FROM (
+    const rows = this.db
+      .prepare(
+        `SELECT id, title, type, created_at FROM (
          SELECT id, title, type, created_at FROM memories
          WHERE created_at <= ?
          ORDER BY created_at DESC LIMIT ?
@@ -445,7 +466,8 @@ export class MemoryStore {
          ORDER BY created_at ASC LIMIT ?
        )
        ORDER BY created_at ASC`
-    ).all(anchorTs, window + 1, anchorTs, window) as Array<Record<string, unknown>>;
+      )
+      .all(anchorTs, window + 1, anchorTs, window) as Array<Record<string, unknown>>;
 
     return rows.map((row) => ({
       id: row.id as string,
@@ -523,17 +545,21 @@ export class MemoryStore {
           trackWrite();
         },
         get: (...params: unknown[]) => {
-          const result = rawDb.exec(sql.replace(/\?/g, () => {
-            const p = params.shift();
-            if (p === null || p === undefined) return 'NULL';
-            if (typeof p === 'string') return `'${p.replace(/'/g, "''")}'`;
-            return String(p);
-          }));
+          const result = rawDb.exec(
+            sql.replace(/\?/g, () => {
+              const p = params.shift();
+              if (p === null || p === undefined) return 'NULL';
+              if (typeof p === 'string') return `'${p.replace(/'/g, "''")}'`;
+              return String(p);
+            })
+          );
           if (!result.length || !result[0].values.length) return undefined;
           const cols = result[0].columns;
           const row = result[0].values[0];
           const obj: Record<string, unknown> = {};
-          cols.forEach((c: string, i: number) => { obj[c] = row[i]; });
+          cols.forEach((c: string, i: number) => {
+            obj[c] = row[i];
+          });
           return obj;
         },
         all: (...params: unknown[]) => {
@@ -552,12 +578,17 @@ export class MemoryStore {
           const cols = result[0].columns;
           return result[0].values.map((row: unknown[]) => {
             const obj: Record<string, unknown> = {};
-            cols.forEach((c: string, i: number) => { obj[c] = row[i]; });
+            cols.forEach((c: string, i: number) => {
+              obj[c] = row[i];
+            });
             return obj;
           });
         },
       }),
-      close: () => { saveToDisk(); rawDb.close(); },
+      close: () => {
+        saveToDisk();
+        rawDb.close();
+      },
       // For saveToDisk() compatibility
       _sqlJsSave: saveToDisk,
       _isSqlJs: true,
@@ -584,37 +615,41 @@ export class MemoryStore {
   saveCodeNode(node: import('../core/indexer/indexer-types.js').CodeNode): void {
     if (!this.db) throw new Error('Database not initialized');
 
-    this.db.prepare(
-      `INSERT OR REPLACE INTO code_nodes (id, type, name, file_path, start_line, end_line, content, summary, hash, updated_at)
+    this.db
+      .prepare(
+        `INSERT OR REPLACE INTO code_nodes (id, type, name, file_path, start_line, end_line, content, summary, hash, updated_at)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
-    ).run(
-      node.id,
-      node.type,
-      node.name,
-      node.filePath,
-      node.startLine,
-      node.endLine,
-      node.content,
-      node.summary ?? null,
-      node.hash,
-      node.updatedAt,
-    );
+      )
+      .run(
+        node.id,
+        node.type,
+        node.name,
+        node.filePath,
+        node.startLine,
+        node.endLine,
+        node.content,
+        node.summary ?? null,
+        node.hash,
+        node.updatedAt
+      );
   }
 
   saveCodeEdge(edge: import('../core/indexer/indexer-types.js').CodeEdge): void {
     if (!this.db) throw new Error('Database not initialized');
 
-    this.db.prepare(
-      `INSERT OR IGNORE INTO code_edges (id, source_id, target_id, type, weight)
+    this.db
+      .prepare(
+        `INSERT OR IGNORE INTO code_edges (id, source_id, target_id, type, weight)
        VALUES (?, ?, ?, ?, ?)`
-    ).run(edge.id, edge.sourceId, edge.targetId, edge.type, edge.weight);
+      )
+      .run(edge.id, edge.sourceId, edge.targetId, edge.type, edge.weight);
   }
 
   getCodeNodeIdsByFile(filePath: string): string[] {
     if (!this.db) return [];
-    const rows = this.db.prepare(
-      `SELECT id FROM code_nodes WHERE file_path = ?`
-    ).all(filePath) as Array<{ id: string }>;
+    const rows = this.db
+      .prepare(`SELECT id FROM code_nodes WHERE file_path = ?`)
+      .all(filePath) as Array<{ id: string }>;
     return rows.map((row) => row.id);
   }
 
@@ -625,9 +660,9 @@ export class MemoryStore {
 
   getCodeNodeByHash(id: string): string | null {
     if (!this.db) throw new Error('Database not initialized');
-    const row = this.db.prepare(
-      `SELECT hash FROM code_nodes WHERE id = ?`
-    ).get(id) as { hash: string } | undefined;
+    const row = this.db.prepare(`SELECT hash FROM code_nodes WHERE id = ?`).get(id) as
+      | { hash: string }
+      | undefined;
     return row?.hash ?? null;
   }
 
@@ -641,9 +676,11 @@ export class MemoryStore {
     updatedAt: number;
   } | null {
     if (!this.db) throw new Error('Database not initialized');
-    const row = this.db.prepare(
-      `SELECT id, type, name, file_path, content, hash, updated_at FROM code_nodes WHERE id = ?`
-    ).get(id) as Record<string, unknown> | undefined;
+    const row = this.db
+      .prepare(
+        `SELECT id, type, name, file_path, content, hash, updated_at FROM code_nodes WHERE id = ?`
+      )
+      .get(id) as Record<string, unknown> | undefined;
 
     if (!row) return null;
     return {

--- a/src/types.ts
+++ b/src/types.ts
@@ -524,7 +524,13 @@ export interface Decision {
 }
 
 export type KnowledgeType = 'pattern' | 'anti-pattern';
-export type KnowledgeCategory = 'architecture' | 'code' | 'testing' | 'security' | 'performance' | 'devops';
+export type KnowledgeCategory =
+  | 'architecture'
+  | 'code'
+  | 'testing'
+  | 'security'
+  | 'performance'
+  | 'devops';
 
 export interface KnowledgeEntry {
   id: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -266,6 +266,14 @@ export interface RulebookConfig {
     autoCapture?: boolean; // default: true
     vectorDimensions?: number; // default: 256
   };
+  // Background indexer configuration (file watcher)
+  indexer?: {
+    watchPaths?: string[]; // default: ['.'] — directories to watch relative to project root
+    ignorePatterns?: string[]; // default: ['node_modules', '.git', 'dist', 'build', '.rulebook', 'coverage']
+    depth?: number; // default: 4 — max directory depth for file watching
+    usePolling?: boolean; // default: false — use polling instead of native watchers (lower FD usage)
+    debounceMs?: number; // default: 3000 — debounce interval for file change events
+  };
   // Ralph autonomous loop configuration (v3.0)
   ralph?: {
     enabled?: boolean; // default: true

--- a/tests/background-indexer.test.ts
+++ b/tests/background-indexer.test.ts
@@ -1,0 +1,298 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Stats } from 'fs';
+
+// Mock chokidar before importing BackgroundIndexer
+const mockWatcher = {
+  on: vi.fn().mockReturnThis(),
+  close: vi.fn(),
+};
+vi.mock('chokidar', () => ({
+  default: {
+    watch: vi.fn(() => mockWatcher),
+  },
+}));
+
+// Mock fs
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return {
+    ...actual,
+    existsSync: vi.fn(() => true),
+    statSync: vi.fn(() => ({ isFile: () => true })),
+  };
+});
+
+import chokidar from 'chokidar';
+import { existsSync } from 'fs';
+import { resolve } from 'path';
+import { BackgroundIndexer } from '../src/core/indexer/background-indexer.js';
+
+const mockMemoryManager = {
+  deleteCodeNodesByFile: vi.fn(),
+  saveCodeNode: vi.fn(),
+  saveCodeEdge: vi.fn(),
+} as any;
+
+describe('BackgroundIndexer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockWatcher.on.mockReturnThis();
+  });
+
+  describe('constructor defaults', () => {
+    it('should default depth to 4', () => {
+      const indexer = new BackgroundIndexer(mockMemoryManager, '/project');
+      // Start to trigger chokidar.watch with the config
+      indexer.start();
+      const watchCall = vi.mocked(chokidar.watch).mock.calls[0];
+      expect(watchCall[1]?.depth).toBe(4);
+    });
+
+    it('should default usePolling to false', () => {
+      const indexer = new BackgroundIndexer(mockMemoryManager, '/project');
+      indexer.start();
+      const watchCall = vi.mocked(chokidar.watch).mock.calls[0];
+      expect(watchCall[1]?.usePolling).toBe(false);
+    });
+
+    it('should accept custom depth', () => {
+      const indexer = new BackgroundIndexer(mockMemoryManager, '/project', { depth: 2 });
+      indexer.start();
+      const watchCall = vi.mocked(chokidar.watch).mock.calls[0];
+      expect(watchCall[1]?.depth).toBe(2);
+    });
+
+    it('should accept custom usePolling', () => {
+      const indexer = new BackgroundIndexer(mockMemoryManager, '/project', { usePolling: true });
+      indexer.start();
+      const watchCall = vi.mocked(chokidar.watch).mock.calls[0];
+      expect(watchCall[1]?.usePolling).toBe(true);
+      // When usePolling is true, interval should be set
+      expect(watchCall[1]?.interval).toBe(2000);
+    });
+  });
+
+  describe('watchPaths resolution', () => {
+    it('should resolve "." to project root', () => {
+      const indexer = new BackgroundIndexer(mockMemoryManager, '/project', {
+        watchPaths: ['.'],
+      });
+      indexer.start();
+      const watchCall = vi.mocked(chokidar.watch).mock.calls[0];
+      const targets = watchCall[0] as string[];
+      expect(targets).toContain(resolve('/project'));
+    });
+
+    it('should resolve relative paths against project root', () => {
+      const indexer = new BackgroundIndexer(mockMemoryManager, '/project', {
+        watchPaths: ['src', 'lib'],
+      });
+      indexer.start();
+      const watchCall = vi.mocked(chokidar.watch).mock.calls[0];
+      const targets = watchCall[0] as string[];
+      expect(targets).toContain(resolve('/project', 'src'));
+      expect(targets).toContain(resolve('/project', 'lib'));
+    });
+
+    it('should filter out non-existent paths', () => {
+      vi.mocked(existsSync).mockImplementation((p) => {
+        return String(p).endsWith('src');
+      });
+      const indexer = new BackgroundIndexer(mockMemoryManager, '/project', {
+        watchPaths: ['src', 'nonexistent'],
+      });
+      indexer.start();
+      const watchCall = vi.mocked(chokidar.watch).mock.calls[0];
+      const targets = watchCall[0] as string[];
+      expect(targets).toHaveLength(1);
+      expect(targets[0]).toContain('src');
+    });
+
+    it('should fall back to project root when no paths exist', () => {
+      vi.mocked(existsSync).mockReturnValue(false);
+      const indexer = new BackgroundIndexer(mockMemoryManager, '/project', {
+        watchPaths: ['nonexistent'],
+      });
+      indexer.start();
+      const watchCall = vi.mocked(chokidar.watch).mock.calls[0];
+      const targets = watchCall[0] as string[];
+      expect(targets).toContain(resolve('/project'));
+    });
+  });
+
+  describe('ignored function', () => {
+    function getIgnoredFn(): (path: string, stats?: Stats) => boolean {
+      const indexer = new BackgroundIndexer(mockMemoryManager, '/project');
+      indexer.start();
+      const watchCall = vi.mocked(chokidar.watch).mock.calls[0];
+      return watchCall[1]?.ignored as (path: string, stats?: Stats) => boolean;
+    }
+
+    it('should use a function-based ignored (not globs)', () => {
+      const ignoredFn = getIgnoredFn();
+      expect(typeof ignoredFn).toBe('function');
+    });
+
+    it('should block node_modules directories', () => {
+      const ignoredFn = getIgnoredFn();
+      const dirStats = { isDirectory: () => true } as Stats;
+      expect(ignoredFn('/project/node_modules', dirStats)).toBe(true);
+    });
+
+    it('should block .git directories', () => {
+      const ignoredFn = getIgnoredFn();
+      const dirStats = { isDirectory: () => true } as Stats;
+      expect(ignoredFn('/project/.git', dirStats)).toBe(true);
+    });
+
+    it('should block dist directories', () => {
+      const ignoredFn = getIgnoredFn();
+      const dirStats = { isDirectory: () => true } as Stats;
+      expect(ignoredFn('/project/dist', dirStats)).toBe(true);
+    });
+
+    it('should block build directories', () => {
+      const ignoredFn = getIgnoredFn();
+      const dirStats = { isDirectory: () => true } as Stats;
+      expect(ignoredFn('/project/build', dirStats)).toBe(true);
+    });
+
+    it('should block coverage directories', () => {
+      const ignoredFn = getIgnoredFn();
+      const dirStats = { isDirectory: () => true } as Stats;
+      expect(ignoredFn('/project/coverage', dirStats)).toBe(true);
+    });
+
+    it('should not block regular source directories', () => {
+      const ignoredFn = getIgnoredFn();
+      const dirStats = { isDirectory: () => true } as Stats;
+      expect(ignoredFn('/project/src', dirStats)).toBe(false);
+    });
+
+    it('should not block files with ignored dir names (e.g. a file named "dist")', () => {
+      const ignoredFn = getIgnoredFn();
+      const fileStats = { isDirectory: () => false } as Stats;
+      expect(ignoredFn('/project/src/dist', fileStats)).toBe(false);
+    });
+
+    it('should block binary file extensions', () => {
+      const ignoredFn = getIgnoredFn();
+      expect(ignoredFn('/project/image.png')).toBe(true);
+      expect(ignoredFn('/project/photo.jpg')).toBe(true);
+      expect(ignoredFn('/project/data.sqlite')).toBe(true);
+      expect(ignoredFn('/project/package-lock.lock')).toBe(true);
+    });
+
+    it('should allow source code files', () => {
+      const ignoredFn = getIgnoredFn();
+      expect(ignoredFn('/project/src/index.ts')).toBe(false);
+      expect(ignoredFn('/project/src/app.js')).toBe(false);
+    });
+
+    it('should block ignored dirs even without stats (initial scan)', () => {
+      const ignoredFn = getIgnoredFn();
+      expect(ignoredFn('/project/node_modules')).toBe(true);
+      expect(ignoredFn('/project/.git')).toBe(true);
+    });
+
+    it('should respect custom ignore patterns', () => {
+      const indexer = new BackgroundIndexer(mockMemoryManager, '/project', {
+        ignorePatterns: ['vendor', '__pycache__'],
+      });
+      indexer.start();
+      const watchCall = vi.mocked(chokidar.watch).mock.calls[0];
+      const ignoredFn = watchCall[1]?.ignored as (path: string, stats?: Stats) => boolean;
+      const dirStats = { isDirectory: () => true } as Stats;
+      expect(ignoredFn('/project/vendor', dirStats)).toBe(true);
+      expect(ignoredFn('/project/__pycache__', dirStats)).toBe(true);
+    });
+  });
+
+  describe('EMFILE recovery', () => {
+    it('should retry with polling on EMFILE error', () => {
+      const indexer = new BackgroundIndexer(mockMemoryManager, '/project');
+      vi.mocked(existsSync).mockReturnValue(true);
+      indexer.start();
+
+      // Get the error handler
+      const errorHandler = mockWatcher.on.mock.calls.find(
+        (call: [string, (...args: any[]) => void]) => call[0] === 'error'
+      )?.[1] as (error: unknown) => void;
+      expect(errorHandler).toBeDefined();
+
+      // Reset mock to track the retry call
+      vi.mocked(chokidar.watch).mockClear();
+      mockWatcher.on.mockReturnThis();
+
+      // Simulate EMFILE error
+      const emfileError = new Error('EMFILE: too many open files') as NodeJS.ErrnoException;
+      emfileError.code = 'EMFILE';
+      errorHandler(emfileError);
+
+      // Should have restarted with polling
+      expect(chokidar.watch).toHaveBeenCalledTimes(1);
+      const retryCall = vi.mocked(chokidar.watch).mock.calls[0];
+      expect(retryCall[1]?.usePolling).toBe(true);
+    });
+
+    it('should not retry more than once on repeated EMFILE', () => {
+      const indexer = new BackgroundIndexer(mockMemoryManager, '/project');
+      vi.mocked(existsSync).mockReturnValue(true);
+      indexer.start();
+
+      const errorHandler = mockWatcher.on.mock.calls.find(
+        (call: [string, (...args: any[]) => void]) => call[0] === 'error'
+      )?.[1] as (error: unknown) => void;
+
+      vi.mocked(chokidar.watch).mockClear();
+      mockWatcher.on.mockReturnThis();
+
+      // First EMFILE: should retry
+      const emfileError = new Error('EMFILE') as NodeJS.ErrnoException;
+      emfileError.code = 'EMFILE';
+      errorHandler(emfileError);
+      expect(chokidar.watch).toHaveBeenCalledTimes(1);
+
+      // Get new error handler from the retry
+      const retryErrorHandler = mockWatcher.on.mock.calls.find(
+        (call: [string, (...args: any[]) => void]) => call[0] === 'error'
+      )?.[1] as (error: unknown) => void;
+
+      vi.mocked(chokidar.watch).mockClear();
+
+      // Second EMFILE: should NOT retry
+      retryErrorHandler(emfileError);
+      expect(chokidar.watch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('disabled state', () => {
+    it('should not start watcher when disabled', () => {
+      const indexer = new BackgroundIndexer(mockMemoryManager, '/project', { enabled: false });
+      indexer.start();
+      expect(chokidar.watch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getStatus', () => {
+    it('should return initial status', () => {
+      const indexer = new BackgroundIndexer(mockMemoryManager, '/project');
+      const status = indexer.getStatus();
+      expect(status).toEqual({
+        queue: 0,
+        processed: 0,
+        errors: 0,
+        isProcessing: false,
+      });
+    });
+  });
+
+  describe('stop', () => {
+    it('should close watcher on stop', () => {
+      const indexer = new BackgroundIndexer(mockMemoryManager, '/project');
+      indexer.start();
+      indexer.stop();
+      expect(mockWatcher.close).toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/claude-plugin.test.ts
+++ b/tests/claude-plugin.test.ts
@@ -53,7 +53,6 @@ describe('Claude Plugin Structure', () => {
       expect(rulebookPlugin).toHaveProperty('description');
       expect(rulebookPlugin).toHaveProperty('version');
     });
-
   });
 
   describe('plugin.json manifest', () => {

--- a/tests/learn-manager.test.ts
+++ b/tests/learn-manager.test.ts
@@ -31,8 +31,10 @@ describe('LearnManager', () => {
       const l = await mgr.capture('Test Learning', 'content');
       const dir = join(testDir, '.rulebook', 'learnings');
       const files = await fs.readdir(dir);
-      expect(files.some(f => f.endsWith('.md') && f.includes('test-learning'))).toBe(true);
-      expect(files.some(f => f.endsWith('.metadata.json') && f.includes('test-learning'))).toBe(true);
+      expect(files.some((f) => f.endsWith('.md') && f.includes('test-learning'))).toBe(true);
+      expect(files.some((f) => f.endsWith('.metadata.json') && f.includes('test-learning'))).toBe(
+        true
+      );
     });
 
     it('should store tags and related task', async () => {
@@ -56,7 +58,7 @@ describe('LearnManager', () => {
     it('should return learnings sorted newest first', async () => {
       await mgr.capture('First', 'content1');
       // Small delay to ensure different timestamps
-      await new Promise(r => setTimeout(r, 10));
+      await new Promise((r) => setTimeout(r, 10));
       await mgr.capture('Second', 'content2');
       const list = await mgr.list();
       expect(list.length).toBe(2);

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -339,170 +339,169 @@ describeOrSkip('MCP Server', () => {
       expect(Array.isArray(results)).toBe(true);
     });
   });
-
 });
 
 // PID file tests are platform-independent — run on all OSes including Windows
 describe('PID File Lock (per-session)', () => {
-    let pidTestDir: string;
+  let pidTestDir: string;
 
-    beforeEach(async () => {
-      pidTestDir = join(tmpdir(), `rulebook-pid-test-${Date.now()}`);
-      await fs.mkdir(join(pidTestDir, '.rulebook'), { recursive: true });
-    });
+  beforeEach(async () => {
+    pidTestDir = join(tmpdir(), `rulebook-pid-test-${Date.now()}`);
+    await fs.mkdir(join(pidTestDir, '.rulebook'), { recursive: true });
+  });
 
-    afterEach(async () => {
-      if (existsSync(pidTestDir)) {
-        await fs.rm(pidTestDir, { recursive: true, force: true });
-      }
-    });
+  afterEach(async () => {
+    if (existsSync(pidTestDir)) {
+      await fs.rm(pidTestDir, { recursive: true, force: true });
+    }
+  });
 
-    it('should create session-scoped PID file with current process PID', () => {
-      const pidPath = acquirePidLock(pidTestDir);
+  it('should create session-scoped PID file with current process PID', () => {
+    const pidPath = acquirePidLock(pidTestDir);
+    expect(existsSync(pidPath)).toBe(true);
+
+    // File should be named mcp-server.<pid>.pid
+    expect(pidPath).toContain(`mcp-server.${process.pid}.pid`);
+
+    const content = readFileSync(pidPath, 'utf8').trim();
+    expect(parseInt(content, 10)).toBe(process.pid);
+
+    releasePidLock(pidPath);
+  });
+
+  it('should release PID file on shutdown', () => {
+    const pidPath = acquirePidLock(pidTestDir);
+    expect(existsSync(pidPath)).toBe(true);
+
+    releasePidLock(pidPath);
+    expect(existsSync(pidPath)).toBe(false);
+  });
+
+  it('should not release PID file if content was changed to another PID', () => {
+    const pidPath = acquirePidLock(pidTestDir);
+
+    // Simulate content overwrite (unlikely but defensive)
+    writeFileSync(pidPath, '999999999', 'utf8');
+
+    releasePidLock(pidPath);
+    // Should NOT have been deleted since PID doesn't match
+    expect(existsSync(pidPath)).toBe(true);
+    expect(readFileSync(pidPath, 'utf8').trim()).toBe('999999999');
+  });
+
+  it('should allow multiple concurrent instances (no process.exit)', () => {
+    // Simulate another alive instance by writing a PID file for current process
+    const otherPidPath = join(pidTestDir, '.rulebook', `mcp-server.${process.pid}.pid`);
+    writeFileSync(otherPidPath, String(process.pid), 'utf8');
+
+    // acquirePidLock should NOT exit — just register (same PID in test, overwrites)
+    const pidPath = acquirePidLock(pidTestDir);
+    expect(existsSync(pidPath)).toBe(true);
+
+    releasePidLock(pidPath);
+  });
+
+  it('should clean stale PID files from dead processes on startup', () => {
+    // Write PID files for processes that don't exist
+    const stale1 = join(pidTestDir, '.rulebook', 'mcp-server.999999991.pid');
+    const stale2 = join(pidTestDir, '.rulebook', 'mcp-server.999999992.pid');
+    writeFileSync(stale1, '999999991', 'utf8');
+    writeFileSync(stale2, '999999992', 'utf8');
+
+    // acquirePidLock cleans stale files on startup
+    const pidPath = acquirePidLock(pidTestDir);
+
+    expect(existsSync(stale1)).toBe(false);
+    expect(existsSync(stale2)).toBe(false);
+    expect(existsSync(pidPath)).toBe(true);
+
+    releasePidLock(pidPath);
+  });
+
+  it('should clean legacy mcp-server.pid if stale', () => {
+    const legacyPath = join(pidTestDir, '.rulebook', 'mcp-server.pid');
+    writeFileSync(legacyPath, '999999999', 'utf8');
+
+    const pidPath = acquirePidLock(pidTestDir);
+
+    // Legacy stale file should be cleaned
+    expect(existsSync(legacyPath)).toBe(false);
+    // Our session PID file should exist
+    expect(existsSync(pidPath)).toBe(true);
+
+    releasePidLock(pidPath);
+  });
+
+  it('should not remove legacy mcp-server.pid if process is alive', () => {
+    const legacyPath = join(pidTestDir, '.rulebook', 'mcp-server.pid');
+    // Write current process PID (alive) as legacy format
+    writeFileSync(legacyPath, String(process.pid), 'utf8');
+
+    const pidPath = acquirePidLock(pidTestDir);
+
+    // Legacy file should be preserved (process is alive)
+    expect(existsSync(legacyPath)).toBe(true);
+    // Our session PID file should also exist
+    expect(existsSync(pidPath)).toBe(true);
+
+    releasePidLock(pidPath);
+  });
+
+  it('should handle corrupt legacy PID file gracefully', () => {
+    const legacyPath = join(pidTestDir, '.rulebook', 'mcp-server.pid');
+    writeFileSync(legacyPath, 'not-a-number', 'utf8');
+
+    const pidPath = acquirePidLock(pidTestDir);
+
+    // Corrupt legacy file should be removed
+    expect(existsSync(legacyPath)).toBe(false);
+    expect(existsSync(pidPath)).toBe(true);
+
+    releasePidLock(pidPath);
+  });
+
+  it('should create .rulebook directory if it does not exist', async () => {
+    const freshDir = join(tmpdir(), `rulebook-pid-fresh-${Date.now()}`);
+    await fs.mkdir(freshDir, { recursive: true });
+
+    try {
+      const pidPath = acquirePidLock(freshDir);
       expect(existsSync(pidPath)).toBe(true);
-
-      // File should be named mcp-server.<pid>.pid
-      expect(pidPath).toContain(`mcp-server.${process.pid}.pid`);
-
-      const content = readFileSync(pidPath, 'utf8').trim();
-      expect(parseInt(content, 10)).toBe(process.pid);
-
       releasePidLock(pidPath);
+    } finally {
+      await fs.rm(freshDir, { recursive: true, force: true });
+    }
+  });
+
+  describe('cleanStalePidFiles', () => {
+    it('should remove only stale PID files', () => {
+      // Stale file (dead PID)
+      const stalePath = join(pidTestDir, '.rulebook', 'mcp-server.999999999.pid');
+      writeFileSync(stalePath, '999999999', 'utf8');
+
+      // Alive file (current process)
+      const alivePath = join(pidTestDir, '.rulebook', `mcp-server.${process.pid}.pid`);
+      writeFileSync(alivePath, String(process.pid), 'utf8');
+
+      cleanStalePidFiles(pidTestDir);
+
+      expect(existsSync(stalePath)).toBe(false);
+      expect(existsSync(alivePath)).toBe(true);
     });
 
-    it('should release PID file on shutdown', () => {
-      const pidPath = acquirePidLock(pidTestDir);
-      expect(existsSync(pidPath)).toBe(true);
-
-      releasePidLock(pidPath);
-      expect(existsSync(pidPath)).toBe(false);
+    it('should handle non-existent .rulebook directory', () => {
+      const emptyDir = join(tmpdir(), `rulebook-pid-empty-${Date.now()}`);
+      // Should not throw
+      expect(() => cleanStalePidFiles(emptyDir)).not.toThrow();
     });
 
-    it('should not release PID file if content was changed to another PID', () => {
-      const pidPath = acquirePidLock(pidTestDir);
+    it('should not touch non-PID files', () => {
+      const otherFile = join(pidTestDir, '.rulebook', 'config.json');
+      writeFileSync(otherFile, '{}', 'utf8');
 
-      // Simulate content overwrite (unlikely but defensive)
-      writeFileSync(pidPath, '999999999', 'utf8');
+      cleanStalePidFiles(pidTestDir);
 
-      releasePidLock(pidPath);
-      // Should NOT have been deleted since PID doesn't match
-      expect(existsSync(pidPath)).toBe(true);
-      expect(readFileSync(pidPath, 'utf8').trim()).toBe('999999999');
+      expect(existsSync(otherFile)).toBe(true);
     });
-
-    it('should allow multiple concurrent instances (no process.exit)', () => {
-      // Simulate another alive instance by writing a PID file for current process
-      const otherPidPath = join(pidTestDir, '.rulebook', `mcp-server.${process.pid}.pid`);
-      writeFileSync(otherPidPath, String(process.pid), 'utf8');
-
-      // acquirePidLock should NOT exit — just register (same PID in test, overwrites)
-      const pidPath = acquirePidLock(pidTestDir);
-      expect(existsSync(pidPath)).toBe(true);
-
-      releasePidLock(pidPath);
-    });
-
-    it('should clean stale PID files from dead processes on startup', () => {
-      // Write PID files for processes that don't exist
-      const stale1 = join(pidTestDir, '.rulebook', 'mcp-server.999999991.pid');
-      const stale2 = join(pidTestDir, '.rulebook', 'mcp-server.999999992.pid');
-      writeFileSync(stale1, '999999991', 'utf8');
-      writeFileSync(stale2, '999999992', 'utf8');
-
-      // acquirePidLock cleans stale files on startup
-      const pidPath = acquirePidLock(pidTestDir);
-
-      expect(existsSync(stale1)).toBe(false);
-      expect(existsSync(stale2)).toBe(false);
-      expect(existsSync(pidPath)).toBe(true);
-
-      releasePidLock(pidPath);
-    });
-
-    it('should clean legacy mcp-server.pid if stale', () => {
-      const legacyPath = join(pidTestDir, '.rulebook', 'mcp-server.pid');
-      writeFileSync(legacyPath, '999999999', 'utf8');
-
-      const pidPath = acquirePidLock(pidTestDir);
-
-      // Legacy stale file should be cleaned
-      expect(existsSync(legacyPath)).toBe(false);
-      // Our session PID file should exist
-      expect(existsSync(pidPath)).toBe(true);
-
-      releasePidLock(pidPath);
-    });
-
-    it('should not remove legacy mcp-server.pid if process is alive', () => {
-      const legacyPath = join(pidTestDir, '.rulebook', 'mcp-server.pid');
-      // Write current process PID (alive) as legacy format
-      writeFileSync(legacyPath, String(process.pid), 'utf8');
-
-      const pidPath = acquirePidLock(pidTestDir);
-
-      // Legacy file should be preserved (process is alive)
-      expect(existsSync(legacyPath)).toBe(true);
-      // Our session PID file should also exist
-      expect(existsSync(pidPath)).toBe(true);
-
-      releasePidLock(pidPath);
-    });
-
-    it('should handle corrupt legacy PID file gracefully', () => {
-      const legacyPath = join(pidTestDir, '.rulebook', 'mcp-server.pid');
-      writeFileSync(legacyPath, 'not-a-number', 'utf8');
-
-      const pidPath = acquirePidLock(pidTestDir);
-
-      // Corrupt legacy file should be removed
-      expect(existsSync(legacyPath)).toBe(false);
-      expect(existsSync(pidPath)).toBe(true);
-
-      releasePidLock(pidPath);
-    });
-
-    it('should create .rulebook directory if it does not exist', async () => {
-      const freshDir = join(tmpdir(), `rulebook-pid-fresh-${Date.now()}`);
-      await fs.mkdir(freshDir, { recursive: true });
-
-      try {
-        const pidPath = acquirePidLock(freshDir);
-        expect(existsSync(pidPath)).toBe(true);
-        releasePidLock(pidPath);
-      } finally {
-        await fs.rm(freshDir, { recursive: true, force: true });
-      }
-    });
-
-    describe('cleanStalePidFiles', () => {
-      it('should remove only stale PID files', () => {
-        // Stale file (dead PID)
-        const stalePath = join(pidTestDir, '.rulebook', 'mcp-server.999999999.pid');
-        writeFileSync(stalePath, '999999999', 'utf8');
-
-        // Alive file (current process)
-        const alivePath = join(pidTestDir, '.rulebook', `mcp-server.${process.pid}.pid`);
-        writeFileSync(alivePath, String(process.pid), 'utf8');
-
-        cleanStalePidFiles(pidTestDir);
-
-        expect(existsSync(stalePath)).toBe(false);
-        expect(existsSync(alivePath)).toBe(true);
-      });
-
-      it('should handle non-existent .rulebook directory', () => {
-        const emptyDir = join(tmpdir(), `rulebook-pid-empty-${Date.now()}`);
-        // Should not throw
-        expect(() => cleanStalePidFiles(emptyDir)).not.toThrow();
-      });
-
-      it('should not touch non-PID files', () => {
-        const otherFile = join(pidTestDir, '.rulebook', 'config.json');
-        writeFileSync(otherFile, '{}', 'utf8');
-
-        cleanStalePidFiles(pidTestDir);
-
-        expect(existsSync(otherFile)).toBe(true);
-      });
-    });
+  });
 });

--- a/tests/memory-coverage.test.ts
+++ b/tests/memory-coverage.test.ts
@@ -77,7 +77,11 @@ describe('MemoryManager — createMemoryManager factory', () => {
 
   it('should create a working manager that can save memories', async () => {
     const mgr = createMemoryManager(testDir, { dbPath: '.rulebook/memory/mem.db' });
-    const saved = await mgr.saveMemory({ type: 'observation', title: 'factory test', content: 'hello' });
+    const saved = await mgr.saveMemory({
+      type: 'observation',
+      title: 'factory test',
+      content: 'hello',
+    });
     expect(saved.id).toBeDefined();
     await mgr.close();
   });
@@ -151,9 +155,7 @@ describe('MemoryManager — saveCodeEdge', () => {
     // Nodes must exist for FK constraint
     await manager.saveCodeNode(makeCodeNode('src1', '/a.ts', 'ha'));
     await manager.saveCodeNode(makeCodeNode('tgt1', '/b.ts', 'hb'));
-    await expect(
-      manager.saveCodeEdge(makeCodeEdge('e1', 'src1', 'tgt1'))
-    ).resolves.not.toThrow();
+    await expect(manager.saveCodeEdge(makeCodeEdge('e1', 'src1', 'tgt1'))).resolves.not.toThrow();
   });
 
   it('should save multiple edges for same source node', async () => {
@@ -162,9 +164,7 @@ describe('MemoryManager — saveCodeEdge', () => {
     await manager.saveCodeNode(makeCodeNode('t2', '/c.ts', 'h3'));
 
     await manager.saveCodeEdge(makeCodeEdge('e1', 's1', 't1'));
-    await expect(
-      manager.saveCodeEdge(makeCodeEdge('e2', 's1', 't2'))
-    ).resolves.not.toThrow();
+    await expect(manager.saveCodeEdge(makeCodeEdge('e2', 's1', 't2'))).resolves.not.toThrow();
   });
 });
 
@@ -190,23 +190,17 @@ describe('MemoryManager — deleteCodeNodesByFile', () => {
     await manager.saveCodeNode(makeCodeNode('n2', '/src/target.ts', 'h2'));
     await manager.saveCodeNode(makeCodeNode('n3', '/src/other.ts', 'h3'));
 
-    await expect(
-      manager.deleteCodeNodesByFile('/src/target.ts')
-    ).resolves.not.toThrow();
+    await expect(manager.deleteCodeNodesByFile('/src/target.ts')).resolves.not.toThrow();
   });
 
   it('should not throw when deleting nodes from a file with no entries', async () => {
-    await expect(
-      manager.deleteCodeNodesByFile('/src/nonexistent.ts')
-    ).resolves.not.toThrow();
+    await expect(manager.deleteCodeNodesByFile('/src/nonexistent.ts')).resolves.not.toThrow();
   });
 
   it('should remove HNSW vectors for deleted code nodes', async () => {
     await manager.saveCodeNode(makeCodeNode('n1', '/src/cleanup.ts', 'hc'));
     // Delete should clean up the HNSW entry (covered by the __code__ prefix path)
-    await expect(
-      manager.deleteCodeNodesByFile('/src/cleanup.ts')
-    ).resolves.not.toThrow();
+    await expect(manager.deleteCodeNodesByFile('/src/cleanup.ts')).resolves.not.toThrow();
   });
 });
 
@@ -251,7 +245,11 @@ describe('MemoryManager — getTimeline and getFullDetails', () => {
 
   it('should retrieve full details for multiple IDs', async () => {
     const m1 = await manager.saveMemory({ type: 'bugfix', title: 'Bug 1', content: 'Fix 1' });
-    const m2 = await manager.saveMemory({ type: 'feature', title: 'Feature 1', content: 'Added 1' });
+    const m2 = await manager.saveMemory({
+      type: 'feature',
+      title: 'Feature 1',
+      content: 'Added 1',
+    });
 
     const details = await manager.getFullDetails([m1.id, m2.id]);
     expect(details).toHaveLength(2);
@@ -317,7 +315,11 @@ describe('MemoryStore — listMemories with project filter', () => {
   });
 
   afterEach(() => {
-    try { store.close(); } catch { /* ignore */ }
+    try {
+      store.close();
+    } catch {
+      /* ignore */
+    }
     rmSync(testDir, { recursive: true, force: true });
   });
 
@@ -364,26 +366,41 @@ describe('MemoryStore — searchBM25 with filters', () => {
   });
 
   afterEach(() => {
-    try { store.close(); } catch { /* ignore */ }
+    try {
+      store.close();
+    } catch {
+      /* ignore */
+    }
     rmSync(testDir, { recursive: true, force: true });
   });
 
   it('should filter BM25 results by type', () => {
-    const m1: Memory = { ...makeMemory('m1', 'authentication feature', 'oauth login'), type: 'feature' };
-    const m2: Memory = { ...makeMemory('m2', 'authentication bugfix', 'oauth login fix'), type: 'bugfix' };
+    const m1: Memory = {
+      ...makeMemory('m1', 'authentication feature', 'oauth login'),
+      type: 'feature',
+    };
+    const m2: Memory = {
+      ...makeMemory('m2', 'authentication bugfix', 'oauth login fix'),
+      type: 'bugfix',
+    };
     store.saveMemory(m1);
     store.saveMemory(m2);
 
     const results = store.searchBM25('authentication', 10, { type: 'feature' });
     // All returned results should be features only
-    expect(results.every((r) => {
-      // We just verify no error was thrown and results are filtered
-      return typeof r.id === 'string' && r.score >= 0;
-    })).toBe(true);
+    expect(
+      results.every((r) => {
+        // We just verify no error was thrown and results are filtered
+        return typeof r.id === 'string' && r.score >= 0;
+      })
+    ).toBe(true);
   });
 
   it('should filter BM25 results by project', () => {
-    const m1: Memory = { ...makeMemory('m1', 'deployment config', 'k8s deployment'), project: 'infra' };
+    const m1: Memory = {
+      ...makeMemory('m1', 'deployment config', 'k8s deployment'),
+      project: 'infra',
+    };
     const m2: Memory = { ...makeMemory('m2', 'deployment script', 'bash deploy'), project: 'app' };
     store.saveMemory(m1);
     store.saveMemory(m2);
@@ -397,11 +414,15 @@ describe('MemoryStore — searchBM25 with filters', () => {
   it('should filter BM25 results by both type and project', () => {
     const m1: Memory = {
       ...makeMemory('m1', 'database migration feature', 'schema change'),
-      type: 'feature', project: 'backend',
+      type: 'feature',
+      project: 'backend',
     };
     store.saveMemory(m1);
 
-    const results = store.searchBM25('database migration', 10, { type: 'feature', project: 'backend' });
+    const results = store.searchBM25('database migration', 10, {
+      type: 'feature',
+      project: 'backend',
+    });
     expect(Array.isArray(results)).toBe(true);
   });
 });
@@ -422,7 +443,11 @@ describe('MemoryStore — getEvictionCandidates with active session', () => {
   });
 
   afterEach(() => {
-    try { store.close(); } catch { /* ignore */ }
+    try {
+      store.close();
+    } catch {
+      /* ignore */
+    }
     rmSync(testDir, { recursive: true, force: true });
   });
 
@@ -498,7 +523,11 @@ describe('MemoryStore — searchLike fallback (FTS5 unavailable)', () => {
   });
 
   afterEach(() => {
-    try { store.close(); } catch { /* ignore */ }
+    try {
+      store.close();
+    } catch {
+      /* ignore */
+    }
     rmSync(testDir, { recursive: true, force: true });
   });
 
@@ -522,7 +551,10 @@ describe('MemoryStore — searchLike fallback (FTS5 unavailable)', () => {
 
   it('should filter searchLike results by type', () => {
     const m1: Memory = { ...makeMemory('m1', 'auth bugfix', 'authentication fix'), type: 'bugfix' };
-    const m2: Memory = { ...makeMemory('m2', 'auth feature', 'authentication addition'), type: 'feature' };
+    const m2: Memory = {
+      ...makeMemory('m2', 'auth feature', 'authentication addition'),
+      type: 'feature',
+    };
     store.saveMemory(m1);
     store.saveMemory(m2);
 
@@ -533,7 +565,10 @@ describe('MemoryStore — searchLike fallback (FTS5 unavailable)', () => {
   });
 
   it('should filter searchLike results by project', () => {
-    const m1: Memory = { ...makeMemory('m1', 'deploy script', 'kubernetes deploy'), project: 'infra' };
+    const m1: Memory = {
+      ...makeMemory('m1', 'deploy script', 'kubernetes deploy'),
+      project: 'infra',
+    };
     const m2: Memory = { ...makeMemory('m2', 'deploy docs', 'deployment guide'), project: 'docs' };
     store.saveMemory(m1);
     store.saveMemory(m2);

--- a/tests/memory-store-backends.test.ts
+++ b/tests/memory-store-backends.test.ts
@@ -23,7 +23,11 @@ describe('MemoryStore — Backend Integration', () => {
   });
 
   afterEach(() => {
-    try { store.close(); } catch { /* ignore */ }
+    try {
+      store.close();
+    } catch {
+      /* ignore */
+    }
     rmSync(testDir, { recursive: true, force: true });
   });
 
@@ -81,7 +85,9 @@ describe('MemoryStore — Backend Integration', () => {
     });
 
     it('should handle special characters in content', () => {
-      store.saveMemory(makeMemory('m1', "It's a test", "Content with 'quotes' and \"double quotes\""));
+      store.saveMemory(
+        makeMemory('m1', "It's a test", 'Content with \'quotes\' and "double quotes"')
+      );
       const mem = store.getMemory('m1');
       expect(mem!.title).toBe("It's a test");
       expect(mem!.content).toContain("'quotes'");
@@ -239,8 +245,20 @@ describe('MemoryStore — Backend Integration', () => {
 
     it('should count sessions', () => {
       expect(store.getSessionCount()).toBe(0);
-      store.createSession({ id: 's1', project: 'test', status: 'active', startedAt: Date.now(), toolCalls: 0 });
-      store.createSession({ id: 's2', project: 'test', status: 'active', startedAt: Date.now(), toolCalls: 0 });
+      store.createSession({
+        id: 's1',
+        project: 'test',
+        status: 'active',
+        startedAt: Date.now(),
+        toolCalls: 0,
+      });
+      store.createSession({
+        id: 's2',
+        project: 'test',
+        status: 'active',
+        startedAt: Date.now(),
+        toolCalls: 0,
+      });
       expect(store.getSessionCount()).toBe(2);
     });
   });
@@ -365,16 +383,37 @@ describe('MemoryStore — Backend Integration', () => {
 
     it('should get code node IDs by file path', () => {
       store.saveCodeNode({
-        id: 'n1', type: 'function', name: 'f1', filePath: '/src/a.ts',
-        startLine: 1, endLine: 5, content: 'code', hash: 'h1', updatedAt: Date.now(),
+        id: 'n1',
+        type: 'function',
+        name: 'f1',
+        filePath: '/src/a.ts',
+        startLine: 1,
+        endLine: 5,
+        content: 'code',
+        hash: 'h1',
+        updatedAt: Date.now(),
       });
       store.saveCodeNode({
-        id: 'n2', type: 'function', name: 'f2', filePath: '/src/a.ts',
-        startLine: 6, endLine: 10, content: 'code', hash: 'h2', updatedAt: Date.now(),
+        id: 'n2',
+        type: 'function',
+        name: 'f2',
+        filePath: '/src/a.ts',
+        startLine: 6,
+        endLine: 10,
+        content: 'code',
+        hash: 'h2',
+        updatedAt: Date.now(),
       });
       store.saveCodeNode({
-        id: 'n3', type: 'function', name: 'f3', filePath: '/src/b.ts',
-        startLine: 1, endLine: 5, content: 'code', hash: 'h3', updatedAt: Date.now(),
+        id: 'n3',
+        type: 'function',
+        name: 'f3',
+        filePath: '/src/b.ts',
+        startLine: 1,
+        endLine: 5,
+        content: 'code',
+        hash: 'h3',
+        updatedAt: Date.now(),
       });
 
       const ids = store.getCodeNodeIdsByFile('/src/a.ts');
@@ -385,8 +424,15 @@ describe('MemoryStore — Backend Integration', () => {
 
     it('should delete code nodes by file path', () => {
       store.saveCodeNode({
-        id: 'n1', type: 'function', name: 'f1', filePath: '/src/a.ts',
-        startLine: 1, endLine: 5, content: 'code', hash: 'h1', updatedAt: Date.now(),
+        id: 'n1',
+        type: 'function',
+        name: 'f1',
+        filePath: '/src/a.ts',
+        startLine: 1,
+        endLine: 5,
+        content: 'code',
+        hash: 'h1',
+        updatedAt: Date.now(),
       });
 
       store.deleteCodeNodesByFile('/src/a.ts');
@@ -395,9 +441,16 @@ describe('MemoryStore — Backend Integration', () => {
 
     it('should get full code node', () => {
       store.saveCodeNode({
-        id: 'n1', type: 'class', name: 'MyClass', filePath: '/src/my.ts',
-        startLine: 1, endLine: 50, content: 'class MyClass {}',
-        summary: 'A test class', hash: 'xyz', updatedAt: 12345,
+        id: 'n1',
+        type: 'class',
+        name: 'MyClass',
+        filePath: '/src/my.ts',
+        startLine: 1,
+        endLine: 50,
+        content: 'class MyClass {}',
+        summary: 'A test class',
+        hash: 'xyz',
+        updatedAt: 12345,
       });
 
       const node = store.getCodeNode('n1');
@@ -413,17 +466,35 @@ describe('MemoryStore — Backend Integration', () => {
   describe('code edges', () => {
     it('should save code edge', () => {
       store.saveCodeNode({
-        id: 'n1', type: 'function', name: 'f1', filePath: '/a.ts',
-        startLine: 1, endLine: 5, content: 'c', hash: 'h1', updatedAt: Date.now(),
+        id: 'n1',
+        type: 'function',
+        name: 'f1',
+        filePath: '/a.ts',
+        startLine: 1,
+        endLine: 5,
+        content: 'c',
+        hash: 'h1',
+        updatedAt: Date.now(),
       });
       store.saveCodeNode({
-        id: 'n2', type: 'function', name: 'f2', filePath: '/b.ts',
-        startLine: 1, endLine: 5, content: 'c', hash: 'h2', updatedAt: Date.now(),
+        id: 'n2',
+        type: 'function',
+        name: 'f2',
+        filePath: '/b.ts',
+        startLine: 1,
+        endLine: 5,
+        content: 'c',
+        hash: 'h2',
+        updatedAt: Date.now(),
       });
 
       expect(() => {
         store.saveCodeEdge({
-          id: 'e1', sourceId: 'n1', targetId: 'n2', type: 'imports', weight: 1.0,
+          id: 'e1',
+          sourceId: 'n1',
+          targetId: 'n2',
+          type: 'imports',
+          weight: 1.0,
         });
       }).not.toThrow();
     });

--- a/tests/memory-store-sqljs-fallback.test.ts
+++ b/tests/memory-store-sqljs-fallback.test.ts
@@ -55,8 +55,14 @@ describe('MemoryStore — sql.js fallback', () => {
 function makeMemory(id: string, title: string, content = 'Test'): Memory {
   const now = Date.now();
   return {
-    id, type: 'observation', title, content,
-    project: 'test', tags: ['test'],
-    createdAt: now, updatedAt: now, accessedAt: now,
+    id,
+    type: 'observation',
+    title,
+    content,
+    project: 'test',
+    tags: ['test'],
+    createdAt: now,
+    updatedAt: now,
+    accessedAt: now,
   };
 }

--- a/tests/migrator.test.ts
+++ b/tests/migrator.test.ts
@@ -74,7 +74,10 @@ Vectorizer-specific content here.
   };
 
   beforeEach(async () => {
-    testDir = path.join(tmpdir(), `rulebook-migrator-test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+    testDir = path.join(
+      tmpdir(),
+      `rulebook-migrator-test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+    );
     await fs.mkdir(testDir, { recursive: true });
   });
 
@@ -478,8 +481,7 @@ React content here.
             name: 'REACT',
             startLine: 2,
             endLine: 4,
-            content:
-              '<!-- REACT:START -->\n# React Rules\nReact content here.\n<!-- REACT:END -->',
+            content: '<!-- REACT:START -->\n# React Rules\nReact content here.\n<!-- REACT:END -->',
           },
           // No VUE block — will trigger generateFrameworkRules
         ],

--- a/tests/multi-tool-integration.test.ts
+++ b/tests/multi-tool-integration.test.ts
@@ -21,7 +21,10 @@ describe('Multi-Tool Integration', () => {
 
     // Create some source files for complexity detection
     for (let i = 0; i < 20; i++) {
-      writeFileSync(join(testDir, 'src', `module${i}.ts`), `export const x${i} = ${i};\n`.repeat(100));
+      writeFileSync(
+        join(testDir, 'src', `module${i}.ts`),
+        `export const x${i} = ${i};\n`.repeat(100)
+      );
     }
     writeFileSync(join(testDir, 'src', 'main.py'), 'x = 1\n'.repeat(100));
 
@@ -44,7 +47,13 @@ describe('Multi-Tool Integration', () => {
     });
 
     it('should install Tier 1 rules from template library', async () => {
-      const tier1Rules = ['no-shortcuts', 'git-safety', 'sequential-editing', 'research-first', 'follow-task-sequence'];
+      const tier1Rules = [
+        'no-shortcuts',
+        'git-safety',
+        'sequential-editing',
+        'research-first',
+        'follow-task-sequence',
+      ];
 
       for (const name of tier1Rules) {
         const result = await installRule(testDir, name, templatesDir);
@@ -54,14 +63,21 @@ describe('Multi-Tool Integration', () => {
       const rules = await loadCanonicalRules(testDir);
       expect(rules.length).toBe(tier1Rules.length);
 
-      const tier1 = rules.filter(r => r.tier === 1);
+      const tier1 = rules.filter((r) => r.tier === 1);
       expect(tier1.length).toBe(tier1Rules.length);
     });
 
     it('should install Tier 2 rules for medium+ complexity', async () => {
       const allRules = [
-        'no-shortcuts', 'git-safety', 'sequential-editing', 'research-first', 'follow-task-sequence',
-        'task-decomposition', 'incremental-tests', 'no-deferred', 'session-workflow',
+        'no-shortcuts',
+        'git-safety',
+        'sequential-editing',
+        'research-first',
+        'follow-task-sequence',
+        'task-decomposition',
+        'incremental-tests',
+        'no-deferred',
+        'session-workflow',
       ];
 
       for (const name of allRules) {
@@ -71,7 +87,7 @@ describe('Multi-Tool Integration', () => {
       const rules = await loadCanonicalRules(testDir);
       expect(rules.length).toBe(allRules.length);
 
-      const tier2 = rules.filter(r => r.tier === 2);
+      const tier2 = rules.filter((r) => r.tier === 2);
       expect(tier2.length).toBeGreaterThan(0);
     });
 
@@ -135,7 +151,9 @@ describe('Multi-Tool Integration', () => {
       expect(existsSync(join(testDir, '.claude', 'agents', 'researcher.md'))).toBe(true);
 
       // Verify memory dirs created
-      expect(existsSync(join(testDir, '.claude', 'agent-memory', 'frontend-engineer', 'MEMORY.md'))).toBe(true);
+      expect(
+        existsSync(join(testDir, '.claude', 'agent-memory', 'frontend-engineer', 'MEMORY.md'))
+      ).toBe(true);
     });
 
     it('should degrade agents to Cursor contextual rules', async () => {
@@ -170,7 +188,10 @@ describe('Multi-Tool Integration', () => {
       expect(ruleResult.cursor.length).toBeGreaterThanOrEqual(3);
 
       // 4. Generate agents
-      const agentResult = await generateAgents(testDir, 'web-app', { claudeCode: true, cursor: true });
+      const agentResult = await generateAgents(testDir, 'web-app', {
+        claudeCode: true,
+        cursor: true,
+      });
       expect(agentResult.claudeCode.length).toBeGreaterThan(0);
       expect(agentResult.cursor.length).toBeGreaterThan(0);
 

--- a/tests/ralph.test.ts
+++ b/tests/ralph.test.ts
@@ -851,7 +851,11 @@ describe('Ralph Autonomous Loop', () => {
         notes: '',
       };
 
-      const config = { enabled: false, requireApprovalForStories: 'none' as const, autoApproveAfterSeconds: 0 };
+      const config = {
+        enabled: false,
+        requireApprovalForStories: 'none' as const,
+        autoApproveAfterSeconds: 0,
+      };
       const result = await manager.runCheckpoint(story, 'claude', config);
       expect(result.proceed).toBe(true);
       expect(checkpoint.generateIterationPlan).not.toHaveBeenCalled();
@@ -872,7 +876,11 @@ describe('Ralph Autonomous Loop', () => {
         notes: '',
       };
 
-      const config = { enabled: true, requireApprovalForStories: 'all' as const, autoApproveAfterSeconds: 0 };
+      const config = {
+        enabled: true,
+        requireApprovalForStories: 'all' as const,
+        autoApproveAfterSeconds: 0,
+      };
       const result = await manager.runCheckpoint(story, 'claude', config);
       expect(result.proceed).toBe(true);
       expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('empty output'));
@@ -894,7 +902,11 @@ describe('Ralph Autonomous Loop', () => {
         notes: '',
       };
 
-      const config = { enabled: true, requireApprovalForStories: 'all' as const, autoApproveAfterSeconds: 0 };
+      const config = {
+        enabled: true,
+        requireApprovalForStories: 'all' as const,
+        autoApproveAfterSeconds: 0,
+      };
       const result = await manager.runCheckpoint(story, 'claude', config);
       expect(result.proceed).toBe(true);
       expect(result.feedback).toBeUndefined();
@@ -919,7 +931,11 @@ describe('Ralph Autonomous Loop', () => {
         notes: '',
       };
 
-      const config = { enabled: true, requireApprovalForStories: 'all' as const, autoApproveAfterSeconds: 0 };
+      const config = {
+        enabled: true,
+        requireApprovalForStories: 'all' as const,
+        autoApproveAfterSeconds: 0,
+      };
       const result = await manager.runCheckpoint(story, 'claude', config);
       expect(result.proceed).toBe(false);
       expect(result.feedback).toBe('Need more detail on step 2');

--- a/tests/rule-engine.test.ts
+++ b/tests/rule-engine.test.ts
@@ -119,10 +119,7 @@ Body content.
 
     it('should skip non-md files', async () => {
       writeFileSync(join(testDir, '.rulebook', 'rules', 'readme.txt'), 'not a rule');
-      writeFileSync(
-        join(testDir, '.rulebook', 'rules', 'real.md'),
-        '---\nname: real\n---\nBody'
-      );
+      writeFileSync(join(testDir, '.rulebook', 'rules', 'real.md'), '---\nname: real\n---\nBody');
 
       const rules = await loadCanonicalRules(testDir);
       expect(rules).toHaveLength(1);
@@ -130,10 +127,7 @@ Body content.
     });
 
     it('should handle rule without frontmatter', async () => {
-      writeFileSync(
-        join(testDir, '.rulebook', 'rules', 'bare.md'),
-        '# A Rule\n\nJust markdown.'
-      );
+      writeFileSync(join(testDir, '.rulebook', 'rules', 'bare.md'), '# A Rule\n\nJust markdown.');
 
       const rules = await loadCanonicalRules(testDir);
       expect(rules).toHaveLength(1);
@@ -181,10 +175,7 @@ Use strict types.
       const result = await projectRules(testDir, { claudeCode: true });
       expect(result.claudeCode).toHaveLength(2);
 
-      const content = readFileSync(
-        join(testDir, '.claude', 'rules', 'no-shortcuts.md'),
-        'utf-8'
-      );
+      const content = readFileSync(join(testDir, '.claude', 'rules', 'no-shortcuts.md'), 'utf-8');
       expect(content).toContain('Never use stubs or TODOs');
     });
 
@@ -192,17 +183,11 @@ Use strict types.
       const result = await projectRules(testDir, { cursor: true });
       expect(result.cursor).toHaveLength(2);
 
-      const content = readFileSync(
-        join(testDir, '.cursor', 'rules', 'no-shortcuts.mdc'),
-        'utf-8'
-      );
+      const content = readFileSync(join(testDir, '.cursor', 'rules', 'no-shortcuts.mdc'), 'utf-8');
       expect(content).toContain('alwaysApply: true');
       expect(content).toContain('Never use stubs or TODOs');
 
-      const tsContent = readFileSync(
-        join(testDir, '.cursor', 'rules', 'ts-only.mdc'),
-        'utf-8'
-      );
+      const tsContent = readFileSync(join(testDir, '.cursor', 'rules', 'ts-only.mdc'), 'utf-8');
       expect(tsContent).toContain('globs:');
       expect(tsContent).toContain('*.ts');
     });
@@ -222,10 +207,7 @@ Use strict types.
       const result = await projectRules(testDir, { copilot: true });
       expect(result.copilot).toHaveLength(1);
 
-      const content = readFileSync(
-        join(testDir, '.github', 'copilot-instructions.md'),
-        'utf-8'
-      );
+      const content = readFileSync(join(testDir, '.github', 'copilot-instructions.md'), 'utf-8');
       expect(content).toContain('<!-- RULEBOOK:START -->');
       expect(content).toContain('Never use stubs or TODOs');
     });
@@ -234,18 +216,14 @@ Use strict types.
       const result = await projectRules(testDir, { windsurf: true });
       // ts-only targets claude-code+cursor only, so windsurf gets 1 rule (no-shortcuts)
       expect(result.windsurf).toHaveLength(1);
-      expect(
-        existsSync(join(testDir, '.windsurf', 'rules', 'no-shortcuts.md'))
-      ).toBe(true);
+      expect(existsSync(join(testDir, '.windsurf', 'rules', 'no-shortcuts.md'))).toBe(true);
     });
 
     it('should project to Continue.dev as individual files', async () => {
       const result = await projectRules(testDir, { continueDev: true });
       // ts-only targets claude-code+cursor only, so continue gets 1 rule (no-shortcuts)
       expect(result.continueDev).toHaveLength(1);
-      expect(
-        existsSync(join(testDir, '.continue', 'rules', 'no-shortcuts.md'))
-      ).toBe(true);
+      expect(existsSync(join(testDir, '.continue', 'rules', 'no-shortcuts.md'))).toBe(true);
     });
 
     it('should only project to detected tools', async () => {

--- a/tests/task-blockers.test.ts
+++ b/tests/task-blockers.test.ts
@@ -14,7 +14,14 @@ describe('Task Blocker Chain', () => {
     // Create minimal .rulebook config
     writeFileSync(
       join(testDir, '.rulebook', 'rulebook.json'),
-      JSON.stringify({ version: '5.0.0', installedAt: new Date().toISOString(), updatedAt: new Date().toISOString(), projectId: 'test', mode: 'full', features: {} })
+      JSON.stringify({
+        version: '5.0.0',
+        installedAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        projectId: 'test',
+        mode: 'full',
+        features: {},
+      })
     );
     tm = new TaskManager(testDir, '.rulebook');
   });
@@ -32,7 +39,10 @@ describe('Task Blocker Chain', () => {
     // Create task directory with metadata
     const taskDir = join(testDir, '.rulebook', 'tasks', 'task-a');
     mkdirSync(taskDir, { recursive: true });
-    writeFileSync(join(taskDir, 'proposal.md'), '# Proposal\n\n## Why\nTest task\n\n## What Changes\nNothing');
+    writeFileSync(
+      join(taskDir, 'proposal.md'),
+      '# Proposal\n\n## Why\nTest task\n\n## What Changes\nNothing'
+    );
     writeFileSync(join(taskDir, 'tasks.md'), '- [ ] Item 1');
     writeFileSync(
       join(taskDir, '.metadata.json'),
@@ -55,7 +65,10 @@ describe('Task Blocker Chain', () => {
   it('should read blockedBy from metadata', async () => {
     const taskDir = join(testDir, '.rulebook', 'tasks', 'task-b');
     mkdirSync(taskDir, { recursive: true });
-    writeFileSync(join(taskDir, 'proposal.md'), '# Proposal\n\n## Why\nTest\n\n## What Changes\nN/A');
+    writeFileSync(
+      join(taskDir, 'proposal.md'),
+      '# Proposal\n\n## Why\nTest\n\n## What Changes\nN/A'
+    );
     writeFileSync(join(taskDir, 'tasks.md'), '- [ ] Item 1');
     writeFileSync(
       join(taskDir, '.metadata.json'),
@@ -76,7 +89,10 @@ describe('Task Blocker Chain', () => {
   it('should return metadata without blocker fields for legacy tasks', async () => {
     const taskDir = join(testDir, '.rulebook', 'tasks', 'old-task');
     mkdirSync(taskDir, { recursive: true });
-    writeFileSync(join(taskDir, 'proposal.md'), '# Proposal\n\n## Why\nTest\n\n## What Changes\nN/A');
+    writeFileSync(
+      join(taskDir, 'proposal.md'),
+      '# Proposal\n\n## Why\nTest\n\n## What Changes\nN/A'
+    );
     writeFileSync(join(taskDir, 'tasks.md'), '- [ ] Item 1');
     writeFileSync(
       join(taskDir, '.metadata.json'),


### PR DESCRIPTION
## Summary

- **Root cause**: chokidar v5's glob-string `ignored` (e.g. `**/node_modules/**`) does not prevent directory traversal — it still opens file descriptors for every directory before filtering. On macOS (default ulimit 256), this caused 60,000+ open FDs and EMFILE crashes.
- **Fix**: Replaced glob-string ignore with a **function-based filter** that prevents chokidar from entering `node_modules`, `.git`, `dist`, `build`, `.rulebook`, and `coverage` directories at the OS watcher level
- **Reduced default watch depth** from 8 to 4
- **`watchPaths` config is now actually used** (previously always watched entire project root)
- **EMFILE auto-recovery**: On EMFILE/ENFILE errors, indexer automatically restarts in polling mode (one retry)
- **New `indexer` config section** in `.rulebook` for customizing `watchPaths`, `ignorePatterns`, `depth`, `usePolling`, `debounceMs`
- **25 new tests** for BackgroundIndexer (ignored function, watchPaths resolution, EMFILE recovery, defaults)
- Version bump to 5.1.3

Closes #14

## Test plan

- [x] `npm run type-check` — passes
- [x] `npm run lint` — no warnings
- [x] `npx vitest run tests/background-indexer.test.ts` — 25 tests pass
- [x] `npm test` — full suite 1685 tests pass, 0 failures
- [ ] Manual: enable `memory.enabled: true`, run `npm run mcp-server`, verify `lsof -p <PID> | wc -l` stays low on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)